### PR TITLE
Add API e2e tests

### DIFF
--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,0 +1,80 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import * as request from 'supertest';
+import { AuthModule } from '../src/auth/auth.module';
+import { UsersModule } from '../src/users/users.module';
+import { User } from '../src/users/user.entity';
+
+describe('Auth API (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [User],
+          synchronize: true,
+        }),
+        UsersModule,
+        AuthModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('registers a user', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ name: 'Alice', email: 'alice@example.com', password: 'Pass@123' })
+      .expect(201);
+
+    expect(res.body).toEqual(
+      expect.objectContaining({ id: expect.any(Number), name: 'Alice', email: 'alice@example.com' }),
+    );
+    expect(res.body.password).toBeUndefined();
+  });
+
+  it('logs in and returns a token', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ name: 'Bob', email: 'bob@example.com', password: 'Pass@123' });
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'bob@example.com', password: 'Pass@123' })
+      .expect(201);
+
+    expect(loginRes.body.access_token).toBeDefined();
+  });
+
+  it('returns profile data for a valid token', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ name: 'Carol', email: 'carol@example.com', password: 'Pass@123' });
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'carol@example.com', password: 'Pass@123' });
+    const token = loginRes.body.access_token;
+
+    const profileRes = await request(app.getHttpServer())
+      .post('/auth/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(201);
+
+    expect(profileRes.body).toEqual({ userId: expect.any(Number), email: 'carol@example.com' });
+  });
+});

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -1,0 +1,88 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import * as request from 'supertest';
+import { AuthModule } from '../src/auth/auth.module';
+import { UsersModule } from '../src/users/users.module';
+import { User } from '../src/users/user.entity';
+
+describe('Users API (e2e)', () => {
+  let app: INestApplication;
+  let token: string;
+  let userId: number;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [User],
+          synchronize: true,
+        }),
+        UsersModule,
+        AuthModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    const regRes = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ name: 'Dave', email: 'dave@example.com', password: 'Pass@123' });
+    userId = regRes.body.id;
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'dave@example.com', password: 'Pass@123' });
+    token = loginRes.body.access_token;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('lists users', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/users')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  it('fetches a user by id', async () => {
+    const res = await request(app.getHttpServer())
+      .get(`/users/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body).toEqual(expect.objectContaining({ id: userId }));
+  });
+
+  it('updates a user', async () => {
+    const res = await request(app.getHttpServer())
+      .put(`/users/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Updated' })
+      .expect(200);
+    expect(res.body).toEqual(expect.objectContaining({ id: userId, name: 'Updated' }));
+  });
+
+  it('removes a user', async () => {
+    await request(app.getHttpServer())
+      .delete(`/users/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const res = await request(app.getHttpServer())
+      .get(`/users/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add e2e tests for auth endpoints
- add e2e tests for user endpoints

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_686d1ae51e4c832280d5509c3b68b7f8