### PR TITLE
fix: include Ionic card components standalone

### DIFF
--- a/frontend/src/app/edit-user/edit-user.page.ts
+++ b/frontend/src/app/edit-user/edit-user.page.ts
@@ -10,6 +10,10 @@ import {
   IonInput,
   IonButton,
   IonItem,
+  IonCard,
+  IonCardHeader,
+  IonCardTitle,
+  IonCardContent,
 } from '@ionic/angular/standalone';
 import { UserService } from '../services/user.service';
 
@@ -28,6 +32,10 @@ import { UserService } from '../services/user.service';
     IonTitle,
     IonInput,
     IonButton,
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardContent,
   ],
 })
 export class EditUserPage implements OnInit {

--- a/frontend/src/app/login/login.page.ts
+++ b/frontend/src/app/login/login.page.ts
@@ -10,6 +10,10 @@ import {
   IonInput,
   IonButton,
   IonItem,
+  IonCard,
+  IonCardHeader,
+  IonCardTitle,
+  IonCardContent,
 } from '@ionic/angular/standalone';
 import { AuthService } from '../services/auth.service';
 
@@ -28,6 +32,10 @@ import { AuthService } from '../services/auth.service';
     IonTitle,
     IonInput,
     IonButton,
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardContent,
   ],
 })
 export class LoginPage {

--- a/frontend/src/app/register/register.page.ts
+++ b/frontend/src/app/register/register.page.ts
@@ -11,6 +11,9 @@ import {
   IonButton,
   IonItem,
   IonCardContent,
+  IonCard,
+  IonCardHeader,
+  IonCardTitle,
 } from '@ionic/angular/standalone';
 import { AuthService } from '../services/auth.service';
 
@@ -30,6 +33,9 @@ import { AuthService } from '../services/auth.service';
     IonTitle,
     IonInput,
     IonButton,
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
   ],
 })
 export class RegisterPage {


### PR DESCRIPTION
## Summary
- import standalone IonCard components in edit-user page
- import standalone IonCard components in login page
- import standalone IonCard components in register page

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1ff3904c83229d8dda5375e343ac