### PR TITLE
Enable CORS in Nest backend

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,6 +5,9 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors({
+    origin: process.env.CORS_ORIGIN || 'http://localhost:8100',
+  });
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
 
   const config = new DocumentBuilder()


### PR DESCRIPTION
## Summary
- enable CORS for the backend

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_686d23edb98483228102059814f1b542