### PR TITLE
Implement responsive validation and UI feedback

### DIFF
--- a/frontend/src/app/edit-user/edit-user.page.ts
+++ b/frontend/src/app/edit-user/edit-user.page.ts
@@ -16,6 +16,7 @@ import {
   IonCardContent,
 } from '@ionic/angular/standalone';
 import { UserService } from '../services/user.service';
+import { UiService } from '../services/ui.service';
 
 @Component({
   selector: 'app-edit-user',
@@ -50,7 +51,8 @@ export class EditUserPage implements OnInit {
     private fb: FormBuilder,
     private userService: UserService,
     private route: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private ui: UiService
   ) {}
 
   ngOnInit() {
@@ -62,11 +64,16 @@ export class EditUserPage implements OnInit {
 
   async save() {
     if (this.form.invalid) return;
-    await this.userService.update(
-      this.id,
-      this.form.value.name!,
-      this.form.value.email!
-    );
-    this.router.navigateByUrl('/users');
+    try {
+      await this.userService.update(
+        this.id,
+        this.form.value.name!,
+        this.form.value.email!
+      );
+      this.ui.toast('User updated', 'success');
+      this.router.navigateByUrl('/users');
+    } catch (err) {
+      this.ui.toast('Update failed', 'danger');
+    }
   }
 }

--- a/frontend/src/app/login/login.page.html
+++ b/frontend/src/app/login/login.page.html
@@ -25,6 +25,8 @@
             label="Password"
             labelPlacement="floating"
             type="password"
+            [class.valid]="form.controls.password.valid && form.controls.password.touched"
+            [class.invalid]="form.controls.password.invalid && form.controls.password.touched"
           ></ion-input>
         </ion-item>
         <ion-button expand="block" type="submit">Login</ion-button>

--- a/frontend/src/app/login/login.page.scss
+++ b/frontend/src/app/login/login.page.scss
@@ -12,3 +12,13 @@ ion-card {
   max-width: 380px;
 }
 
+ion-input.invalid {
+  --highlight-color-focused: var(--ion-color-danger);
+  --highlight-color: var(--ion-color-danger);
+}
+
+ion-input.valid {
+  --highlight-color-focused: var(--ion-color-success);
+  --highlight-color: var(--ion-color-success);
+}
+

--- a/frontend/src/app/login/login.page.ts
+++ b/frontend/src/app/login/login.page.ts
@@ -16,6 +16,7 @@ import {
   IonCardContent,
 } from '@ionic/angular/standalone';
 import { AuthService } from '../services/auth.service';
+import { UiService } from '../services/ui.service';
 
 @Component({
   selector: 'app-login',
@@ -41,19 +42,31 @@ import { AuthService } from '../services/auth.service';
 export class LoginPage {
   form = this.fb.group({
     email: ['', [Validators.required, Validators.email]],
-    password: ['', Validators.required],
+    password: [
+      '',
+      [Validators.required, Validators.pattern(/^(?=.*[^A-Za-z0-9]).{8,}$/)],
+    ],
   });
 
   constructor(
     private fb: FormBuilder,
     private auth: AuthService,
-    private router: Router
+    private router: Router,
+    private ui: UiService
   ) {}
 
   async login() {
     if (this.form.invalid) return;
-    await this.auth.login(this.form.value.email!, this.form.value.password!);
-    this.router.navigateByUrl('/users');
+    try {
+      await this.auth.login(
+        this.form.value.email!,
+        this.form.value.password!
+      );
+      this.ui.toast('Login successful', 'success');
+      this.router.navigateByUrl('/users');
+    } catch (err) {
+      this.ui.toast('Login failed', 'danger');
+    }
   }
 
   goToRegister() {

--- a/frontend/src/app/register/register.page.html
+++ b/frontend/src/app/register/register.page.html
@@ -32,6 +32,8 @@
             label="Password"
             labelPlacement="floating"
             type="password"
+            [class.valid]="form.controls.password.valid && form.controls.password.touched"
+            [class.invalid]="form.controls.password.invalid && form.controls.password.touched"
           ></ion-input>
         </ion-item>
         <ion-button expand="block" type="submit">Save</ion-button>

--- a/frontend/src/app/register/register.page.scss
+++ b/frontend/src/app/register/register.page.scss
@@ -12,3 +12,13 @@ ion-card {
   max-width: 380px;
 }
 
+ion-input.invalid {
+  --highlight-color-focused: var(--ion-color-danger);
+  --highlight-color: var(--ion-color-danger);
+}
+
+ion-input.valid {
+  --highlight-color-focused: var(--ion-color-success);
+  --highlight-color: var(--ion-color-success);
+}
+

--- a/frontend/src/app/register/register.page.ts
+++ b/frontend/src/app/register/register.page.ts
@@ -16,6 +16,7 @@ import {
   IonCardTitle,
 } from '@ionic/angular/standalone';
 import { AuthService } from '../services/auth.service';
+import { UiService } from '../services/ui.service';
 
 @Component({
   selector: 'app-register',
@@ -42,22 +43,31 @@ export class RegisterPage {
   form = this.fb.group({
     name: ['', Validators.required],
     email: ['', [Validators.required, Validators.email]],
-    password: ['', [Validators.required, Validators.minLength(8)]],
+    password: [
+      '',
+      [Validators.required, Validators.pattern(/^(?=.*[^A-Za-z0-9]).{8,}$/)],
+    ],
   });
 
   constructor(
     private fb: FormBuilder,
     private auth: AuthService,
-    private router: Router
+    private router: Router,
+    private ui: UiService
   ) {}
 
   async register() {
     if (this.form.invalid) return;
-    await this.auth.register(
-      this.form.value.name!,
-      this.form.value.email!,
-      this.form.value.password!
-    );
-    this.router.navigateByUrl('/login');
+    try {
+      await this.auth.register(
+        this.form.value.name!,
+        this.form.value.email!,
+        this.form.value.password!
+      );
+      this.ui.toast('User created', 'success');
+      this.router.navigateByUrl('/login');
+    } catch (err) {
+      this.ui.toast('Registration failed', 'danger');
+    }
   }
 }

--- a/frontend/src/app/services/ui.service.ts
+++ b/frontend/src/app/services/ui.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { AlertController, ToastController } from '@ionic/angular';
+
+@Injectable({ providedIn: 'root' })
+export class UiService {
+  constructor(private toastCtrl: ToastController, private alertCtrl: AlertController) {}
+
+  async toast(message: string, color: 'success' | 'danger' | 'warning' | 'primary' = 'primary') {
+    const toast = await this.toastCtrl.create({ message, duration: 2000, color, position: 'bottom' });
+    await toast.present();
+  }
+
+  async confirm(message: string): Promise<boolean> {
+    const alert = await this.alertCtrl.create({
+      header: 'Confirm',
+      message,
+      buttons: [
+        { text: 'Cancel', role: 'cancel' },
+        { text: 'OK', role: 'confirm' }
+      ]
+    });
+    await alert.present();
+    const { role } = await alert.onDidDismiss();
+    return role === 'confirm';
+  }
+}

--- a/frontend/src/app/users/users.page.ts
+++ b/frontend/src/app/users/users.page.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { IonContent, IonHeader, IonToolbar, IonTitle, IonList, IonItem, IonLabel, IonButton, IonButtons } from '@ionic/angular/standalone';
 import { UserService, User } from '../services/user.service';
 import { AuthService } from '../services/auth.service';
+import { UiService } from '../services/ui.service';
 
 @Component({
   selector: 'app-users',
@@ -15,7 +16,12 @@ import { AuthService } from '../services/auth.service';
 export class UsersPage implements OnInit {
   users: User[] = [];
 
-  constructor(private userService: UserService, private auth: AuthService, private router: Router) {}
+  constructor(
+    private userService: UserService,
+    private auth: AuthService,
+    private router: Router,
+    private ui: UiService
+  ) {}
 
   ngOnInit() {
     this.load();
@@ -34,12 +40,20 @@ export class UsersPage implements OnInit {
   }
 
   async deleteUser(user: User) {
-    await this.userService.delete(user.id);
-    this.load();
+    const ok = await this.ui.confirm('Delete user?');
+    if (!ok) return;
+    try {
+      await this.userService.delete(user.id);
+      this.ui.toast('User deleted', 'success');
+      this.load();
+    } catch (err) {
+      this.ui.toast('Delete failed', 'danger');
+    }
   }
 
   logout() {
     this.auth.logout();
     this.router.navigateByUrl('/login');
+    this.ui.toast('Logged out', 'success');
   }
 }


### PR DESCRIPTION
## Summary
- add generic UI service for confirmation modals and toast messages
- validate passwords with regex and highlight inputs
- display success/error toasts in login, register and user pages
- add confirmation dialog before user deletion and notify on logout
- tweak styles for input validation feedback

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*
- `npm test` in backend *(fails: jest not found)*
- `npm run lint` in backend *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_686d27aef5488322af44839ea9ae8ea6