### PR TITLE
Fix user list refresh after edit

### DIFF
--- a/frontend/src/app/users/users.page.ts
+++ b/frontend/src/app/users/users.page.ts
@@ -27,6 +27,10 @@ export class UsersPage implements OnInit {
     this.load();
   }
 
+  ionViewWillEnter() {
+    this.load();
+  }
+
   async load() {
     this.users = await this.userService.findAll();
   }


### PR DESCRIPTION
## Summary
- make `UsersPage` reload data whenever it becomes active

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686d298864d883229887dec2539b9bab