### PR TITLE
Logout after self delete

### DIFF
--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -1,11 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
+import { UsersService } from '../users/users.service';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(configService: ConfigService) {
+  constructor(
+    configService: ConfigService,
+    private readonly usersService: UsersService,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -14,6 +18,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { userId: payload.sub, email: payload.username };
+    const user = await this.usersService.findOne(payload.sub);
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+    return { userId: user.id, email: user.email };
   }
 }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -34,6 +34,17 @@ export class AuthService {
     return localStorage.getItem('token');
   }
 
+  get userId(): number | null {
+    const token = this.token;
+    if (!token) return null;
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      return payload.sub ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   isLoggedIn(): boolean {
     return !!this.token;
   }

--- a/frontend/src/app/users/users.page.ts
+++ b/frontend/src/app/users/users.page.ts
@@ -45,7 +45,11 @@ export class UsersPage implements OnInit {
     try {
       await this.userService.delete(user.id);
       this.ui.toast('User deleted', 'success');
-      this.load();
+      if (user.id === this.auth.userId) {
+        this.logout();
+      } else {
+        this.load();
+      }
     } catch (err) {
       this.ui.toast('Delete failed', 'danger');
     }


### PR DESCRIPTION
## Summary
- verify JWT user existence on validate
- expose `userId` in frontend auth service
- logout when deleting self

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails due to missing Chrome)

------
https://chatgpt.com/codex/tasks/task_e_686d299e060c832298d7359c48546605