### PR TITLE
Add modal user creation

### DIFF
--- a/frontend/src/app/add-user/add-user-modal.component.html
+++ b/frontend/src/app/add-user/add-user-modal.component.html
@@ -1,0 +1,40 @@
+<ion-modal [isOpen]="isOpen" (didDismiss)="close()">
+  <ng-template>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Add User</ion-title>
+        <ion-buttons slot="end">
+          <ion-button (click)="close()">Close</ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="login-container">
+      <form [formGroup]="form" (ngSubmit)="save()">
+        <ion-item>
+          <ion-input
+            formControlName="name"
+            label="Name"
+            labelPlacement="floating"
+          ></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-input
+            formControlName="email"
+            label="Email"
+            labelPlacement="floating"
+            type="email"
+          ></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-input
+            formControlName="password"
+            label="Password"
+            labelPlacement="floating"
+            type="password"
+          ></ion-input>
+        </ion-item>
+        <ion-button expand="block" type="submit">Save</ion-button>
+      </form>
+    </ion-content>
+  </ng-template>
+</ion-modal>

--- a/frontend/src/app/add-user/add-user-modal.component.scss
+++ b/frontend/src/app/add-user/add-user-modal.component.scss
@@ -1,0 +1,1 @@
+/* Empty styling */

--- a/frontend/src/app/add-user/add-user-modal.component.ts
+++ b/frontend/src/app/add-user/add-user-modal.component.ts
@@ -1,0 +1,79 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import {
+  IonButton,
+  IonInput,
+  IonItem,
+  IonModal,
+  IonButtons,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+} from '@ionic/angular/standalone';
+import { UserService } from '../services/user.service';
+import { UiService } from '../services/ui.service';
+
+@Component({
+  selector: 'app-add-user-modal',
+  templateUrl: './add-user-modal.component.html',
+  styleUrls: ['./add-user-modal.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    IonButton,
+    IonInput,
+    IonItem,
+    IonModal,
+    IonButtons,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+  ],
+})
+export class AddUserModalComponent {
+  isOpen = false;
+  @Output() userCreated = new EventEmitter<void>();
+  form = this.fb.group({
+    name: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    password: [
+      '',
+      [Validators.required, Validators.pattern(/^(?=.*[^A-Za-z0-9]).{8,}$/)],
+    ],
+  });
+
+  constructor(
+    private fb: FormBuilder,
+    private userService: UserService,
+    private ui: UiService
+  ) {}
+
+  open() {
+    this.isOpen = true;
+  }
+
+  close() {
+    this.isOpen = false;
+    this.form.reset();
+  }
+
+  async save() {
+    if (this.form.invalid) return;
+    try {
+      await this.userService.create(
+        this.form.value.name!,
+        this.form.value.email!,
+        this.form.value.password!
+      );
+      this.ui.toast('User created', 'success');
+      this.userCreated.emit();
+      this.close();
+    } catch (err) {
+      this.ui.toast('Create failed', 'danger');
+    }
+  }
+}

--- a/frontend/src/app/register/register.page.html
+++ b/frontend/src/app/register/register.page.html
@@ -4,40 +4,6 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="login-container">
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>Register</ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <form [formGroup]="form" (ngSubmit)="register()">
-        <ion-item>
-          <ion-input
-            formControlName="name"
-            label="Name"
-            labelPlacement="floating"
-          ></ion-input>
-        </ion-item>
-        <ion-item>
-          <ion-input
-            formControlName="email"
-            label="Email"
-            labelPlacement="floating"
-            type="email"
-          ></ion-input>
-        </ion-item>
-        <ion-item>
-          <ion-input
-            formControlName="password"
-            label="Password"
-            labelPlacement="floating"
-            type="password"
-            [class.valid]="form.controls.password.valid && form.controls.password.touched"
-            [class.invalid]="form.controls.password.invalid && form.controls.password.touched"
-          ></ion-input>
-        </ion-item>
-        <ion-button expand="block" type="submit">Save</ion-button>
-      </form>
-    </ion-card-content>
-  </ion-card>
+<ion-content>
+  <app-add-user-modal #modal (userCreated)="handleCreated()"></app-add-user-modal>
 </ion-content>

--- a/frontend/src/app/register/register.page.ts
+++ b/frontend/src/app/register/register.page.ts
@@ -1,22 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild, AfterViewInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
-import {
-  IonContent,
-  IonHeader,
-  IonToolbar,
-  IonTitle,
-  IonInput,
-  IonButton,
-  IonItem,
-  IonCardContent,
-  IonCard,
-  IonCardHeader,
-  IonCardTitle,
-} from '@ionic/angular/standalone';
-import { AuthService } from '../services/auth.service';
-import { UiService } from '../services/ui.service';
+import { IonContent, IonHeader, IonToolbar, IonTitle } from '@ionic/angular/standalone';
+import { AddUserModalComponent } from '../add-user/add-user-modal.component';
 
 @Component({
   selector: 'app-register',
@@ -24,50 +10,24 @@ import { UiService } from '../services/ui.service';
   styleUrls: ['./register.page.scss'],
   standalone: true,
   imports: [
-    IonItem,
-    IonCardContent,
     CommonModule,
-    ReactiveFormsModule,
     IonContent,
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonInput,
-    IonButton,
-    IonCard,
-    IonCardHeader,
-    IonCardTitle,
+    AddUserModalComponent,
   ],
 })
-export class RegisterPage {
-  form = this.fb.group({
-    name: ['', Validators.required],
-    email: ['', [Validators.required, Validators.email]],
-    password: [
-      '',
-      [Validators.required, Validators.pattern(/^(?=.*[^A-Za-z0-9]).{8,}$/)],
-    ],
-  });
+export class RegisterPage implements AfterViewInit {
+  @ViewChild(AddUserModalComponent) modal!: AddUserModalComponent;
 
-  constructor(
-    private fb: FormBuilder,
-    private auth: AuthService,
-    private router: Router,
-    private ui: UiService
-  ) {}
+  constructor(private router: Router) {}
 
-  async register() {
-    if (this.form.invalid) return;
-    try {
-      await this.auth.register(
-        this.form.value.name!,
-        this.form.value.email!,
-        this.form.value.password!
-      );
-      this.ui.toast('User created', 'success');
-      this.router.navigateByUrl('/login');
-    } catch (err) {
-      this.ui.toast('Registration failed', 'danger');
-    }
+  ngAfterViewInit() {
+    this.modal.open();
+  }
+
+  handleCreated() {
+    this.router.navigateByUrl('/login');
   }
 }

--- a/frontend/src/app/users/users.page.html
+++ b/frontend/src/app/users/users.page.html
@@ -19,4 +19,5 @@
       <ion-button fill="clear" color="danger" slot="end" (click)="deleteUser(user)">Delete</ion-button>
     </ion-item>
   </ion-list>
+  <app-add-user-modal #addModal></app-add-user-modal>
 </ion-content>

--- a/frontend/src/app/users/users.page.ts
+++ b/frontend/src/app/users/users.page.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { IonContent, IonHeader, IonToolbar, IonTitle, IonList, IonItem, IonLabel, IonButton, IonButtons } from '@ionic/angular/standalone';
+import { AddUserModalComponent } from '../add-user/add-user-modal.component';
 import { UserService, User } from '../services/user.service';
 import { AuthService } from '../services/auth.service';
 import { UiService } from '../services/ui.service';
@@ -11,10 +12,23 @@ import { UiService } from '../services/ui.service';
   templateUrl: './users.page.html',
   styleUrls: ['./users.page.scss'],
   standalone: true,
-  imports: [CommonModule, IonContent, IonHeader, IonToolbar, IonTitle, IonList, IonItem, IonLabel, IonButton, IonButtons],
+  imports: [
+    CommonModule,
+    IonContent,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonButton,
+    IonButtons,
+    AddUserModalComponent,
+  ],
 })
 export class UsersPage implements OnInit {
   users: User[] = [];
+  @ViewChild(AddUserModalComponent) addModal!: AddUserModalComponent;
 
   constructor(
     private userService: UserService,
@@ -36,7 +50,7 @@ export class UsersPage implements OnInit {
   }
 
   addUser() {
-    this.router.navigateByUrl('/register');
+    this.addModal.open();
   }
 
   editUser(user: User) {


### PR DESCRIPTION
## Summary
- implement `AddUserModalComponent` for adding users
- use the modal on the users page
- rework the register page to open the same modal

## Testing
- `npm test --silent` *(fails: `ng` not found)*
- `npx jest` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_686d3371db1c8322a95e0d649c80a378