### PR TITLE
Add edit modal and fix add-user

### DIFF
--- a/frontend/src/app/edit-user-modal/edit-user-modal.component.html
+++ b/frontend/src/app/edit-user-modal/edit-user-modal.component.html
@@ -1,0 +1,41 @@
+<ion-modal class="ion-modal" [isOpen]="isOpen" (didDismiss)="close()">
+  <ng-template>
+    <ion-card-header>
+      <ion-card-title>Edit User</ion-card-title>
+      <ion-buttons slot="end">
+        <ion-button (click)="close()" fill="clear">
+          <ion-icon name="close-outline"></ion-icon>
+        </ion-button>
+      </ion-buttons>
+    </ion-card-header>
+
+    <ion-card-content>
+      <form [formGroup]="form" (ngSubmit)="save()">
+        <ion-item>
+          <ion-input
+            formControlName="name"
+            label="Name"
+            labelPlacement="floating"
+          ></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-input
+            formControlName="email"
+            label="Email"
+            labelPlacement="floating"
+            type="email"
+          ></ion-input>
+        </ion-item>
+        <ion-button
+          expand="block"
+          fill="solid"
+          color="primary"
+          class="save-button"
+          type="submit"
+        >
+          Save
+        </ion-button>
+      </form>
+    </ion-card-content>
+  </ng-template>
+</ion-modal>

--- a/frontend/src/app/edit-user-modal/edit-user-modal.component.scss
+++ b/frontend/src/app/edit-user-modal/edit-user-modal.component.scss
@@ -1,0 +1,13 @@
+.modal-card {
+  margin: 0;
+  border-radius: var(--ion-card-border-radius);
+  box-shadow: var(--ion-card-box-shadow);
+}
+
+ion-item {
+  margin-bottom: 0.75rem;
+}
+
+.save-button {
+  margin-top: 1rem;
+}

--- a/frontend/src/app/edit-user-modal/edit-user-modal.component.ts
+++ b/frontend/src/app/edit-user-modal/edit-user-modal.component.ts
@@ -1,4 +1,3 @@
-// src/app/add-user/add-user-modal.component.ts
 import { Component, EventEmitter, Output } from '@angular/core';
 import { IonicModule } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
@@ -8,26 +7,21 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
-import { UserService } from '../services/user.service';
+import { UserService, User } from '../services/user.service';
 import { UiService } from '../services/ui.service';
 
-export interface User {
-  name: string;
-  email: string;
-  password: string;
-}
-
 @Component({
-  selector: 'app-add-user-modal',
+  selector: 'app-edit-user-modal',
   standalone: true,
   imports: [IonicModule, CommonModule, ReactiveFormsModule],
-  templateUrl: './add-user-modal.component.html',
-  styleUrls: ['./add-user-modal.component.scss'],
+  templateUrl: './edit-user-modal.component.html',
+  styleUrls: ['./edit-user-modal.component.scss'],
 })
-export class AddUserModalComponent {
-  @Output() userCreated = new EventEmitter<User>();
+export class EditUserModalComponent {
+  @Output() userUpdated = new EventEmitter<User>();
   isOpen = false;
   form: FormGroup;
+  private currentUser!: User;
 
   constructor(
     private fb: FormBuilder,
@@ -37,11 +31,12 @@ export class AddUserModalComponent {
     this.form = this.fb.group({
       name: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
-      password: ['', [Validators.required, Validators.minLength(6)]],
     });
   }
 
-  open() {
+  open(user: User) {
+    this.currentUser = user;
+    this.form.patchValue({ name: user.name, email: user.email });
     this.isOpen = true;
   }
 
@@ -56,16 +51,16 @@ export class AddUserModalComponent {
       return;
     }
     try {
-      const user = await this.userService.create(
+      const updated = await this.userService.update(
+        this.currentUser.id,
         this.form.value.name!,
         this.form.value.email!,
-        this.form.value.password!,
       );
-      this.userCreated.emit(user);
-      this.ui.toast('User created', 'success');
+      this.userUpdated.emit(updated);
+      this.ui.toast('User updated', 'success');
       this.close();
     } catch (err) {
-      this.ui.toast('Create failed', 'danger');
+      this.ui.toast('Update failed', 'danger');
     }
   }
 }

--- a/frontend/src/app/users/users.page.html
+++ b/frontend/src/app/users/users.page.html
@@ -61,5 +61,6 @@
     </table>
   </div>
 
-  <app-add-user-modal #addModal></app-add-user-modal>
+  <app-add-user-modal #addModal (userCreated)="userAdded($event)"></app-add-user-modal>
+  <app-edit-user-modal #editModal (userUpdated)="userUpdated($event)"></app-edit-user-modal>
 </ion-content>

--- a/frontend/src/app/users/users.page.ts
+++ b/frontend/src/app/users/users.page.ts
@@ -23,6 +23,7 @@ import {
   IonCardContent,
 } from '@ionic/angular/standalone';
 import { AddUserModalComponent } from '../add-user/add-user-modal.component';
+import { EditUserModalComponent } from '../edit-user-modal/edit-user-modal.component';
 import { UserService, User } from '../services/user.service';
 import { AuthService } from '../services/auth.service';
 import { UiService } from '../services/ui.service';
@@ -54,11 +55,13 @@ import { UiService } from '../services/ui.service';
     IonButton,
     IonButtons,
     AddUserModalComponent,
+    EditUserModalComponent,
   ],
 })
 export class UsersPage implements OnInit {
   users: User[] = [];
   @ViewChild(AddUserModalComponent) addModal!: AddUserModalComponent;
+  @ViewChild(EditUserModalComponent) editModal!: EditUserModalComponent;
 
   constructor(
     private userService: UserService,
@@ -83,8 +86,19 @@ export class UsersPage implements OnInit {
     this.addModal.open();
   }
 
+  userAdded(user: User) {
+    this.users.push(user);
+  }
+
   editUser(user: User) {
-    this.router.navigate(['/users', user.id, 'edit']);
+    this.editModal.open(user);
+  }
+
+  userUpdated(updated: User) {
+    const index = this.users.findIndex((u) => u.id === updated.id);
+    if (index > -1) {
+      this.users[index] = updated;
+    }
   }
 
   async deleteUser(user: User) {


### PR DESCRIPTION
## Summary
- create `EditUserModalComponent` for editing users
- wire up `AddUserModalComponent` to actually create users
- integrate new modals in Users page

## Testing
- `npm test` *(fails: No binary for Chrome)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e6682c4e0832298f9bd2bd925945b