### PR TITLE
Fix Ionic configuration for module-based project

### DIFF
--- a/frontend/ionic.config.json
+++ b/frontend/ionic.config.json
@@ -1,5 +1,5 @@
 {
   "name": "ionic-app-base",
   "integrations": {},
-  "type": "angular-standalone"
+  "type": "angular"
 }


### PR DESCRIPTION
## Summary
- set `ionic.config.json` type to `angular` so Angular modules compile correctly

## Testing
- `npm run lint` *(fails: prefer-inject errors)*
- `npm test --silent` *(fails: missing Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_686ec75adc608322bd1abaca550bc8aa