### PR TITLE
Implement global HTTP error handler

### DIFF
--- a/frontend/src/app/add-user/add-user-modal.component.ts
+++ b/frontend/src/app/add-user/add-user-modal.component.ts
@@ -58,8 +58,8 @@ export class AddUserModalComponent {
       this.userCreated.emit(user);
       this.ui.toast('User created', 'success');
       this.close();
-    } catch (err) {
-      this.ui.toast('Create failed', 'danger');
+    } catch {
+      // error handled globally
     }
   }
 }

--- a/frontend/src/app/auth/pages/login/login.page.ts
+++ b/frontend/src/app/auth/pages/login/login.page.ts
@@ -2,7 +2,6 @@
 import { Component } from '@angular/core';
 import {
   NavController,
-  ToastController,
   LoadingController,
 } from '@ionic/angular';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
@@ -20,7 +19,6 @@ export class LoginPage {
     private fb: FormBuilder,
     private authService: AuthService,
     private navCtrl: NavController,
-    private toastCtrl: ToastController,
     private loadingCtrl: LoadingController,
   ) {
     this.form = this.fb.group({
@@ -43,14 +41,9 @@ export class LoginPage {
       await this.authService.login(email, password);
       await loading.dismiss();
       this.navCtrl.navigateRoot('/users');
-    } catch (err: any) {
+    } catch {
       await loading.dismiss();
-      const toast = await this.toastCtrl.create({
-        message: err?.message || 'Login failed',
-        duration: 3000,
-        color: 'danger',
-      });
-      await toast.present();
+      // handled globally by interceptor
     }
   }
 

--- a/frontend/src/app/auth/pages/register/register.page.ts
+++ b/frontend/src/app/auth/pages/register/register.page.ts
@@ -2,7 +2,6 @@
 import { Component } from '@angular/core';
 import {
   NavController,
-  ToastController,
   LoadingController,
 } from '@ionic/angular';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
@@ -20,7 +19,6 @@ export class RegisterPage {
     private fb: FormBuilder,
     private authService: AuthService,
     private navCtrl: NavController,
-    private toastCtrl: ToastController,
     private loadingCtrl: LoadingController,
   ) {
     this.form = this.fb.group({
@@ -46,14 +44,9 @@ export class RegisterPage {
       await this.authService.register(name, email, password);
       await loading.dismiss();
       this.navCtrl.navigateRoot('/users');
-    } catch (err: any) {
+    } catch {
       await loading.dismiss();
-      const toast = await this.toastCtrl.create({
-        message: err?.message || 'Registration failed',
-        duration: 3000,
-        color: 'danger',
-      });
-      await toast.present();
+      // handled globally by interceptor
     }
   }
 

--- a/frontend/src/app/core/core.module.ts
+++ b/frontend/src/app/core/core.module.ts
@@ -4,6 +4,7 @@ import { AuthService } from '../auth/services/auth.service';
 import { UserService } from '../users/services/user.service';
 import { UiService } from './services/ui.service';
 import { authInterceptor } from './interceptors/auth.interceptor';
+import { HttpErrorInterceptor } from './interceptors/http-error.interceptor';
 
 @NgModule({
   imports: [HttpClientModule],
@@ -12,6 +13,7 @@ import { authInterceptor } from './interceptors/auth.interceptor';
     UserService,
     UiService,
     { provide: HTTP_INTERCEPTORS, useValue: authInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: HttpErrorInterceptor, multi: true },
   ],
 })
 export class CoreModule {}

--- a/frontend/src/app/core/interceptors/http-error.interceptor.ts
+++ b/frontend/src/app/core/interceptors/http-error.interceptor.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { ToastService } from '../../shared/toast.service';
+import { ErrorTranslatorService } from '../services/error-translator.service';
+
+@Injectable()
+export class HttpErrorInterceptor implements HttpInterceptor {
+  constructor(
+    private toast: ToastService,
+    private translator: ErrorTranslatorService,
+  ) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      catchError((error: HttpErrorResponse) => {
+        const code = error?.error?.internalCode;
+        const message = this.translator.translate(code);
+        this.toast.error(message);
+        return throwError(() => error);
+      }),
+    );
+  }
+}

--- a/frontend/src/app/core/services/error-translator.service.ts
+++ b/frontend/src/app/core/services/error-translator.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ErrorTranslatorService {
+  private readonly messages: Record<string, string> = {
+    AUTH_001: 'E-mail ou senha incorretos.',
+    AUTH_002: 'Sua sessão expirou. Faça login novamente.',
+    AUTH_003: 'Token inválido.',
+    AUTH_004: 'Você precisa estar logado.',
+    AUTH_005: 'Acesso não autorizado.',
+    USER_001: 'Usuário não encontrado.',
+    USER_002: 'Este e-mail já está em uso.',
+    USER_003: 'Dados inválidos.',
+    USER_004: 'Erro ao excluir usuário.',
+    USER_005: 'Erro ao atualizar dados.',
+    VALIDATION_001: 'Preencha todos os campos obrigatórios.',
+    VALIDATION_002: 'Há campos com formato inválido.',
+    VALIDATION_003: 'O conteúdo enviado é muito grande.',
+    DB_001: 'Erro de conexão com o servidor.',
+    DB_002: 'A operação não é permitida.',
+    DB_003: 'Erro ao acessar os dados.',
+    GENERIC_001: 'Erro inesperado. Tente novamente.',
+    GENERIC_002: 'Verifique sua conexão com a internet.',
+    GENERIC_003: 'Serviço temporariamente indisponível.',
+  };
+
+  translate(code: string): string {
+    return this.messages[code] || 'Algo deu errado. Tente novamente.';
+  }
+}

--- a/frontend/src/app/edit-user-modal/edit-user-modal.component.ts
+++ b/frontend/src/app/edit-user-modal/edit-user-modal.component.ts
@@ -59,8 +59,8 @@ export class EditUserModalComponent {
       this.userUpdated.emit(updated);
       this.ui.toast('User updated', 'success');
       this.close();
-    } catch (err) {
-      this.ui.toast('Update failed', 'danger');
+    } catch {
+      // error handled globally
     }
   }
 }

--- a/frontend/src/app/login/login.page.ts
+++ b/frontend/src/app/login/login.page.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 import {
   IonicModule,
   NavController,
-  ToastController,
   LoadingController,
 } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
@@ -29,7 +28,6 @@ export class LoginPage {
     private fb: FormBuilder,
     private authService: AuthService,
     private navCtrl: NavController,
-    private toastCtrl: ToastController,
     private loadingCtrl: LoadingController
   ) {
     this.form = this.fb.group({
@@ -52,14 +50,9 @@ export class LoginPage {
       await this.authService.login(email, password);
       await loading.dismiss();
       this.navCtrl.navigateRoot('/users');
-    } catch (err: any) {
+    } catch {
       await loading.dismiss();
-      const toast = await this.toastCtrl.create({
-        message: err?.message || 'Login failed',
-        duration: 3000,
-        color: 'danger',
-      });
-      await toast.present();
+      // handled globally by interceptor
     }
   }
 

--- a/frontend/src/app/register/register.page.ts
+++ b/frontend/src/app/register/register.page.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 import {
   IonicModule,
   NavController,
-  ToastController,
   LoadingController,
 } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
@@ -29,7 +28,6 @@ export class RegisterPage {
     private fb: FormBuilder,
     private authService: AuthService,
     private navCtrl: NavController,
-    private toastCtrl: ToastController,
     private loadingCtrl: LoadingController
   ) {
     this.form = this.fb.group({
@@ -55,14 +53,9 @@ export class RegisterPage {
       await this.authService.register(name, email, password);
       await loading.dismiss();
       this.navCtrl.navigateRoot('/users');
-    } catch (err: any) {
+    } catch {
       await loading.dismiss();
-      const toast = await this.toastCtrl.create({
-        message: err?.message || 'Registration failed',
-        duration: 3000,
-        color: 'danger',
-      });
-      await toast.present();
+      // handled globally by interceptor
     }
   }
 

--- a/frontend/src/app/shared/toast.service.ts
+++ b/frontend/src/app/shared/toast.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { ToastController } from '@ionic/angular';
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  constructor(private toastController: ToastController) {}
+
+  async error(message: string) {
+    const toast = await this.toastController.create({
+      message,
+      duration: 3000,
+      color: 'danger',
+      position: 'top',
+    });
+    toast.present();
+  }
+
+  async success(message: string) {
+    const toast = await this.toastController.create({
+      message,
+      duration: 2000,
+      color: 'success',
+      position: 'top',
+    });
+    toast.present();
+  }
+}

--- a/frontend/src/app/users/components/add-user/add-user-modal.component.ts
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.ts
@@ -56,8 +56,8 @@ export class AddUserModalComponent {
       this.userCreated.emit(user);
       this.ui.toast('User created', 'success');
       this.close();
-    } catch (err) {
-      this.ui.toast('Create failed', 'danger');
+    } catch {
+      // error handled globally
     }
   }
 }

--- a/frontend/src/app/users/components/edit-user-modal/edit-user-modal.component.ts
+++ b/frontend/src/app/users/components/edit-user-modal/edit-user-modal.component.ts
@@ -57,8 +57,8 @@ export class EditUserModalComponent {
       this.userUpdated.emit(updated);
       this.ui.toast('User updated', 'success');
       this.close();
-    } catch (err) {
-      this.ui.toast('Update failed', 'danger');
+    } catch {
+      // error handled globally
     }
   }
 }

--- a/frontend/src/app/users/pages/users.page.ts
+++ b/frontend/src/app/users/pages/users.page.ts
@@ -78,8 +78,8 @@ export class UsersPage implements OnInit {
       } else {
         this.load();
       }
-    } catch (err) {
-      this.ui.toast('Delete failed', 'danger');
+    } catch {
+      // error handled globally
     }
   }
 

--- a/frontend/src/app/users/users.page.ts
+++ b/frontend/src/app/users/users.page.ts
@@ -94,8 +94,8 @@ export class UsersPage implements OnInit {
       } else {
         this.load();
       }
-    } catch (err) {
-      this.ui.toast('Delete failed', 'danger');
+    } catch {
+      // error handled globally
     }
   }
 


### PR DESCRIPTION
## Summary
- create `ErrorTranslatorService` to map backend internal codes to user-friendly text
- add `HttpErrorInterceptor` that displays translated errors via a new `ToastService`
- provide the interceptor in `CoreModule`
- remove manual error toasts from pages and components

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecff87fa0832290d7766c61761b94