### PR TITLE
Implement friendly error handling

### DIFF
--- a/backend/src/application/use-cases/auth/login.use-case.ts
+++ b/backend/src/application/use-cases/auth/login.use-case.ts
@@ -3,6 +3,8 @@ import { JwtService } from '@nestjs/jwt';
 import { IUserRepository } from '../../../domain/repositories/user.repository';
 import { ICryptoService } from '../../../domain/services/crypto.service';
 import { LoginDto } from '../../dto/login.dto';
+import { AppException } from '../../../shared/exceptions/app.exception';
+import { ErrorCodes } from '../../../shared/exceptions/error-codes';
 
 @Injectable()
 export class LoginUseCase {
@@ -12,11 +14,23 @@ export class LoginUseCase {
     private readonly jwt: JwtService,
   ) {}
 
-  async execute(dto: LoginDto): Promise<{ access_token: string } | null> {
+  async execute(dto: LoginDto): Promise<{ access_token: string }> {
     const user = await this.usersRepo.findByEmail(dto.email);
-    if (!user) return null;
+    if (!user) {
+      throw new AppException(
+        ErrorCodes.AUTH.INVALID_CREDENTIALS.code,
+        ErrorCodes.AUTH.INVALID_CREDENTIALS.message,
+        401,
+      );
+    }
     const valid = await this.crypto.compare(dto.password, user.password);
-    if (!valid) return null;
+    if (!valid) {
+      throw new AppException(
+        ErrorCodes.AUTH.INVALID_CREDENTIALS.code,
+        ErrorCodes.AUTH.INVALID_CREDENTIALS.message,
+        401,
+      );
+    }
     const payload = { username: user.email, sub: user.id };
     return { access_token: this.jwt.sign(payload) };
   }

--- a/backend/src/application/use-cases/user/create-user.use-case.ts
+++ b/backend/src/application/use-cases/user/create-user.use-case.ts
@@ -3,6 +3,8 @@ import { IUserRepository } from '../../../domain/repositories/user.repository';
 import { ICryptoService } from '../../../domain/services/crypto.service';
 import { CreateUserDto } from '../../dto/create-user.dto';
 import { User } from '../../../domain/entities/user.entity';
+import { AppException } from '../../../shared/exceptions/app.exception';
+import { ErrorCodes } from '../../../shared/exceptions/error-codes';
 
 @Injectable()
 export class CreateUserUseCase {
@@ -12,6 +14,14 @@ export class CreateUserUseCase {
   ) {}
 
   async execute(dto: CreateUserDto): Promise<User> {
+    const exists = await this.usersRepo.findByEmail(dto.email);
+    if (exists) {
+      throw new AppException(
+        ErrorCodes.USER.EMAIL_ALREADY_EXISTS.code,
+        ErrorCodes.USER.EMAIL_ALREADY_EXISTS.message,
+      );
+    }
+
     const password = await this.crypto.hash(dto.password);
     return this.usersRepo.create({ ...dto, password });
   }

--- a/backend/src/application/use-cases/user/delete-user.use-case.ts
+++ b/backend/src/application/use-cases/user/delete-user.use-case.ts
@@ -1,5 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IUserRepository } from '../../../domain/repositories/user.repository';
+import { AppException } from '../../../shared/exceptions/app.exception';
+import { ErrorCodes } from '../../../shared/exceptions/error-codes';
 
 @Injectable()
 export class DeleteUserUseCase {
@@ -7,7 +9,15 @@ export class DeleteUserUseCase {
     @Inject('IUserRepository') private readonly usersRepo: IUserRepository,
   ) {}
 
-  execute(id: number): Promise<void> {
-    return this.usersRepo.remove(id);
+  async execute(id: number): Promise<void> {
+    try {
+      await this.usersRepo.remove(id);
+    } catch (err) {
+      throw new AppException(
+        ErrorCodes.USER.DELETION_FAILED.code,
+        ErrorCodes.USER.DELETION_FAILED.message,
+        400,
+      );
+    }
   }
 }

--- a/backend/src/application/use-cases/user/get-user.use-case.ts
+++ b/backend/src/application/use-cases/user/get-user.use-case.ts
@@ -1,6 +1,8 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IUserRepository } from '../../../domain/repositories/user.repository';
 import { User } from '../../../domain/entities/user.entity';
+import { AppException } from '../../../shared/exceptions/app.exception';
+import { ErrorCodes } from '../../../shared/exceptions/error-codes';
 
 @Injectable()
 export class GetUserUseCase {
@@ -8,7 +10,15 @@ export class GetUserUseCase {
     @Inject('IUserRepository') private readonly usersRepo: IUserRepository,
   ) {}
 
-  execute(id: number): Promise<User | null> {
-    return this.usersRepo.findOne(id);
+  async execute(id: number): Promise<User> {
+    const user = await this.usersRepo.findOne(id);
+    if (!user) {
+      throw new AppException(
+        ErrorCodes.USER.USER_NOT_FOUND.code,
+        ErrorCodes.USER.USER_NOT_FOUND.message,
+        404,
+      );
+    }
+    return user;
   }
 }

--- a/backend/src/application/use-cases/user/update-user.use-case.ts
+++ b/backend/src/application/use-cases/user/update-user.use-case.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable } from '@nestjs/common';
 import { IUserRepository } from '../../../domain/repositories/user.repository';
 import { UpdateUserDto } from '../../dto/update-user.dto';
 import { User } from '../../../domain/entities/user.entity';
+import { AppException } from '../../../shared/exceptions/app.exception';
+import { ErrorCodes } from '../../../shared/exceptions/error-codes';
 
 @Injectable()
 export class UpdateUserUseCase {
@@ -10,6 +12,14 @@ export class UpdateUserUseCase {
   ) {}
 
   async execute(id: number, dto: UpdateUserDto): Promise<User> {
-    return this.usersRepo.update(id, dto);
+    try {
+      return await this.usersRepo.update(id, dto);
+    } catch (err) {
+      throw new AppException(
+        ErrorCodes.USER.UPDATE_FAILED.code,
+        ErrorCodes.USER.UPDATE_FAILED.message,
+        400,
+      );
+    }
   }
 }

--- a/backend/src/interface/http/guards/jwt-auth.guard.ts
+++ b/backend/src/interface/http/guards/jwt-auth.guard.ts
@@ -1,5 +1,32 @@
 import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { AppException } from '../../../shared/exceptions/app.exception';
+import { ErrorCodes } from '../../../shared/exceptions/error-codes';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  handleRequest(err: any, user: any, info: any, context: any, status?: any) {
+    if (err || !user) {
+      if (info?.name === 'TokenExpiredError') {
+        throw new AppException(
+          ErrorCodes.AUTH.TOKEN_EXPIRED.code,
+          ErrorCodes.AUTH.TOKEN_EXPIRED.message,
+          401,
+        );
+      }
+      if (info?.message === 'No auth token') {
+        throw new AppException(
+          ErrorCodes.AUTH.MISSING_TOKEN.code,
+          ErrorCodes.AUTH.MISSING_TOKEN.message,
+          401,
+        );
+      }
+      throw new AppException(
+        ErrorCodes.AUTH.TOKEN_INVALID.code,
+        ErrorCodes.AUTH.TOKEN_INVALID.message,
+        401,
+      );
+    }
+    return super.handleRequest(err, user, info, context, status);
+  }
+}

--- a/backend/src/interface/http/guards/jwt.strategy.ts
+++ b/backend/src/interface/http/guards/jwt.strategy.ts
@@ -1,8 +1,10 @@
-import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { IUserRepository } from '../../../domain/repositories/user.repository';
+import { AppException } from '../../../shared/exceptions/app.exception';
+import { ErrorCodes } from '../../../shared/exceptions/error-codes';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -20,7 +22,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(payload: any) {
     const user = await this.usersRepo.findOne(payload.sub);
     if (!user) {
-      throw new UnauthorizedException();
+      throw new AppException(
+        ErrorCodes.AUTH.UNAUTHORIZED_ACCESS.code,
+        ErrorCodes.AUTH.UNAUTHORIZED_ACCESS.message,
+        401,
+      );
     }
     return { userId: user.id, email: user.email };
   }

--- a/backend/src/interface/http/guards/local.strategy.ts
+++ b/backend/src/interface/http/guards/local.strategy.ts
@@ -1,7 +1,9 @@
 import { Strategy } from 'passport-local';
 import { PassportStrategy } from '@nestjs/passport';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AuthService } from '../../../infrastructure/services/auth.service';
+import { AppException } from '../../../shared/exceptions/app.exception';
+import { ErrorCodes } from '../../../shared/exceptions/error-codes';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
@@ -12,7 +14,11 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   async validate(email: string, password: string): Promise<any> {
     const user = await this.authService.validateUser(email, password);
     if (!user) {
-      throw new UnauthorizedException();
+      throw new AppException(
+        ErrorCodes.AUTH.INVALID_CREDENTIALS.code,
+        ErrorCodes.AUTH.INVALID_CREDENTIALS.message,
+        401,
+      );
     }
     return user;
   }

--- a/backend/src/interface/http/interceptors/error.interceptor.ts
+++ b/backend/src/interface/http/interceptors/error.interceptor.ts
@@ -1,0 +1,30 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { AppException } from '../../../shared/exceptions/app.exception';
+import { ErrorCodes } from '../../../shared/exceptions/error-codes';
+
+@Injectable()
+export class ErrorInterceptor implements NestInterceptor {
+  intercept(_: ExecutionContext, next: CallHandler): Observable<any> {
+    return next.handle().pipe(
+      catchError((error) => {
+        if (error instanceof AppException) return throwError(() => error);
+
+        return throwError(
+          () =>
+            new AppException(
+              ErrorCodes.GENERAL.UNKNOWN_ERROR.code,
+              ErrorCodes.GENERAL.UNKNOWN_ERROR.message,
+              500,
+            ),
+        );
+      }),
+    );
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,10 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { ErrorInterceptor } from './interface/http/interceptors/error.interceptor';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalInterceptors(new ErrorInterceptor());
   app.enableCors({
     origin: process.env.CORS_ORIGIN || 'http://localhost:8100',
   });

--- a/backend/src/shared/exceptions/app.exception.ts
+++ b/backend/src/shared/exceptions/app.exception.ts
@@ -1,0 +1,12 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class AppException extends HttpException {
+  constructor(
+    public readonly internalCode: string,
+    public readonly userMessage: string,
+    statusCode: HttpStatus = HttpStatus.BAD_REQUEST,
+    public readonly meta?: unknown,
+  ) {
+    super({ internalCode, userMessage }, statusCode);
+  }
+}

--- a/backend/src/shared/exceptions/error-codes.ts
+++ b/backend/src/shared/exceptions/error-codes.ts
@@ -1,0 +1,92 @@
+export const ErrorCodes = {
+  AUTH: {
+    INVALID_CREDENTIALS: {
+      code: 'AUTH_001',
+      message: 'E-mail ou senha incorretos.',
+    },
+    TOKEN_EXPIRED: {
+      code: 'AUTH_002',
+      message: 'Sua sessão expirou. Faça login novamente.',
+    },
+    TOKEN_INVALID: {
+      code: 'AUTH_003',
+      message: 'Token de acesso inválido.',
+    },
+    MISSING_TOKEN: {
+      code: 'AUTH_004',
+      message: 'Você precisa estar logado para acessar este recurso.',
+    },
+    UNAUTHORIZED_ACCESS: {
+      code: 'AUTH_005',
+      message: 'Acesso não autorizado.',
+    },
+  },
+
+  USER: {
+    USER_NOT_FOUND: {
+      code: 'USER_001',
+      message: 'Usuário não encontrado.',
+    },
+    EMAIL_ALREADY_EXISTS: {
+      code: 'USER_002',
+      message: 'Este e-mail já está em uso. Tente outro.',
+    },
+    INVALID_USER_DATA: {
+      code: 'USER_003',
+      message: 'Alguns dados fornecidos são inválidos.',
+    },
+    DELETION_FAILED: {
+      code: 'USER_004',
+      message: 'Não foi possível excluir o usuário.',
+    },
+    UPDATE_FAILED: {
+      code: 'USER_005',
+      message: 'Não foi possível atualizar os dados do usuário.',
+    },
+  },
+
+  VALIDATION: {
+    MISSING_FIELDS: {
+      code: 'VALIDATION_001',
+      message: 'Campos obrigatórios não foram preenchidos.',
+    },
+    INVALID_FORMAT: {
+      code: 'VALIDATION_002',
+      message: 'Formato inválido em um ou mais campos.',
+    },
+    PAYLOAD_TOO_LARGE: {
+      code: 'VALIDATION_003',
+      message: 'O envio ultrapassa o tamanho permitido.',
+    },
+  },
+
+  DATABASE: {
+    CONNECTION_FAILED: {
+      code: 'DB_001',
+      message: 'Erro ao conectar ao banco de dados.',
+    },
+    CONSTRAINT_VIOLATION: {
+      code: 'DB_002',
+      message: 'A operação violou uma restrição do banco.',
+    },
+    QUERY_FAILED: {
+      code: 'DB_003',
+      message: 'Erro ao consultar ou salvar dados no banco.',
+    },
+  },
+
+  GENERAL: {
+    UNKNOWN_ERROR: {
+      code: 'GENERIC_001',
+      message: 'Ocorreu um erro inesperado. Tente novamente.',
+    },
+    NETWORK_ERROR: {
+      code: 'GENERIC_002',
+      message: 'Falha de comunicação com o servidor. Verifique sua conexão.',
+    },
+    SERVICE_UNAVAILABLE: {
+      code: 'GENERIC_003',
+      message: 'Serviço temporariamente indisponível.',
+    },
+  },
+} as const;


### PR DESCRIPTION
## Summary
- add AppException and friendly error catalog
- create global error interceptor
- use new error system in auth and user use cases
- customize auth guards to return friendly errors
- register interceptor in main bootstrap

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: No tests found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ecf6ada448322bef207da74efa7d4