### PR TITLE
Fix auth getter usage

### DIFF
--- a/frontend/src/app/auth/services/auth.service.ts
+++ b/frontend/src/app/auth/services/auth.service.ts
@@ -48,6 +48,14 @@ export class AuthService {
     }
   }
 
+  /**
+   * Temporary helper to access the logged in user id.
+   * Allows templates using `auth.user` to keep working.
+   */
+  get user(): number | null {
+    return this.userId;
+  }
+
   isLoggedIn(): boolean {
     return !!this.token;
   }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -45,6 +45,16 @@ export class AuthService {
     }
   }
 
+  /**
+   * Temporary helper to access the logged in user id.
+   *
+   * Some components expect `auth.user` to exist. Exposing a
+   * getter avoids template errors without changing the API.
+   */
+  get user(): number | null {
+    return this.userId;
+  }
+
   isLoggedIn(): boolean {
     return !!this.token;
   }


### PR DESCRIPTION
## Summary
- expose `user` getter in frontend AuthService for compatibility

## Testing
- `npm run build`
- `npm test --silent` *(fails: No Chrome binary)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870056a98fc8322b89eebd580710b13