### PR TITLE
Fix current user lookup in UsersPage

### DIFF
--- a/frontend/src/app/users/users.page.html
+++ b/frontend/src/app/users/users.page.html
@@ -12,7 +12,7 @@
       <ion-card>
         <ion-card-content>
           <h3>Total de Usuários</h3>
-          <p>{{ users?.length }}</p>
+          <p>{{ users.length }}</p>
         </ion-card-content>
       </ion-card>
       <ion-card>

--- a/frontend/src/app/users/users.page.ts
+++ b/frontend/src/app/users/users.page.ts
@@ -62,8 +62,9 @@ export class UsersPage implements OnInit {
   async load() {
     this.users = await this.userService.findAll();
 
-    // ✅ Supondo que o AuthService tenha `user` preenchido após login
-    this.currentUser = this.auth.user;
+    // get the userId from the token and resolve the current user
+    const id = this.auth.userId;
+    this.currentUser = id ? this.users.find((u) => u.id === id) ?? null : null;
   }
 
   filteredUsers(): User[] {


### PR DESCRIPTION
## Summary
- resolve current user by ID instead of assigning numeric ID to `currentUser`
- remove unnecessary optional chaining in template

## Testing
- `npm run test:e2e` *(fails: Unable to connect to the database)*
- `npm test -- --watch=false` in `frontend` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6870d83749e88322a2589963425089be