### PR TITLE
Fix users route path

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -14,7 +14,8 @@ export const routes: Routes = [
   {
     path: 'users',
     canActivate: [authGuard],
-    loadComponent: () => import('./users/users.page').then((m) => m.UsersPage),
+    loadChildren: () =>
+      import('./users/users.module').then((m) => m.UsersModule),
   },
   {
     path: '',


### PR DESCRIPTION
## Summary
- load the UsersModule via loadChildren instead of loadComponent so Angular can resolve Ionic components

## Testing
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6870f8420f808322bdda8ca7b5e9db18