### PR TITLE
Fix standalone component declarations

### DIFF
--- a/frontend/src/app/users/components/add-user/add-user-modal.component.ts
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.ts
@@ -13,6 +13,8 @@ import { UiService } from '../../../core/services/ui.service';
 
 @Component({
   selector: 'app-add-user-modal',
+  standalone: true,
+  imports: [IonicModule, CommonModule, ReactiveFormsModule],
   templateUrl: './add-user-modal.component.html',
   styleUrls: ['./add-user-modal.component.scss'],
 })

--- a/frontend/src/app/users/components/edit-user-modal/edit-user-modal.component.ts
+++ b/frontend/src/app/users/components/edit-user-modal/edit-user-modal.component.ts
@@ -12,6 +12,8 @@ import { UiService } from '../../../core/services/ui.service';
 
 @Component({
   selector: 'app-edit-user-modal',
+  standalone: true,
+  imports: [IonicModule, CommonModule, ReactiveFormsModule],
   templateUrl: './edit-user-modal.component.html',
   styleUrls: ['./edit-user-modal.component.scss'],
 })

--- a/frontend/src/app/users/users-routing.module.ts
+++ b/frontend/src/app/users/users-routing.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { UsersPage } from './pages/users.page';
+import { UsersPage } from './users.page';
 
 const routes: Routes = [{ path: '', component: UsersPage }];
 

--- a/frontend/src/app/users/users.module.ts
+++ b/frontend/src/app/users/users.module.ts
@@ -3,18 +3,20 @@ import { CommonModule } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { UsersRoutingModule } from './users-routing.module';
-import { UsersPage } from './pages/users.page';
+import { UsersPage } from './users.page';
 import { AddUserModalComponent } from './components/add-user/add-user-modal.component';
 import { EditUserModalComponent } from './components/edit-user-modal/edit-user-modal.component';
 
 @NgModule({
-  declarations: [UsersPage, AddUserModalComponent, EditUserModalComponent],
   imports: [
     CommonModule,
     IonicModule,
     FormsModule,
     ReactiveFormsModule,
     UsersRoutingModule,
+    UsersPage,
+    AddUserModalComponent,
+    EditUserModalComponent,
   ],
 })
 export class UsersModule {}


### PR DESCRIPTION
## Summary
- mark modal components as standalone
- import standalone components into UsersModule
- update UsersRoutingModule to use standalone UsersPage

## Testing
- `npm run lint` *(fails: prefer-inject rule)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870fcf78fd08322a053f8271da721cc