### PR TITLE
Add responsive header and sidebar

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,3 +1,9 @@
 <ion-app>
-  <ion-router-outlet></ion-router-outlet>
+  <ion-split-pane when="(min-width: 768px)" contentId="main" *ngIf="auth.isLoggedIn(); else basic">
+    <app-sidebar></app-sidebar>
+    <ion-router-outlet id="main"></ion-router-outlet>
+  </ion-split-pane>
+  <ng-template #basic>
+    <ion-router-outlet id="main"></ion-router-outlet>
+  </ng-template>
 </ion-app>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,12 +1,14 @@
 import { Component } from '@angular/core';
-import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { IonApp, IonRouterOutlet, IonSplitPane } from '@ionic/angular/standalone';
+import { SidebarComponent } from './shared/sidebar/sidebar.component';
+import { AuthService } from './services/auth.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: 'app.component.html',
   standalone: true,
-  imports: [IonApp, IonRouterOutlet],
+  imports: [IonApp, IonRouterOutlet, IonSplitPane, SidebarComponent],
 })
 export class AppComponent {
-  constructor() {}
+  constructor(public auth: AuthService) {}
 }

--- a/frontend/src/app/shared/header/header.component.html
+++ b/frontend/src/app/shared/header/header.component.html
@@ -1,0 +1,13 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-menu-button></ion-menu-button>
+    </ion-buttons>
+    <ion-title>Dashboard</ion-title>
+    <ion-buttons slot="end">
+      <ion-button fill="clear" (click)="logout()">
+        <ion-icon slot="icon-only" name="log-out-outline"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>

--- a/frontend/src/app/shared/header/header.component.scss
+++ b/frontend/src/app/shared/header/header.component.scss
@@ -1,0 +1,5 @@
+/* simple spacing for header elements */
+ion-toolbar {
+  --padding-start: 16px;
+  --padding-end: 16px;
+}

--- a/frontend/src/app/shared/header/header.component.ts
+++ b/frontend/src/app/shared/header/header.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [IonicModule],
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss']
+})
+export class HeaderComponent {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  logout() {
+    this.auth.logout();
+    this.router.navigateByUrl('/login');
+  }
+}

--- a/frontend/src/app/shared/sidebar/sidebar.component.html
+++ b/frontend/src/app/shared/sidebar/sidebar.component.html
@@ -1,0 +1,17 @@
+<ion-menu contentId="main" type="overlay">
+  <ion-header>
+    <ion-toolbar color="primary">
+      <ion-title>Menu</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <ion-list>
+      <ion-menu-toggle auto-hide="false">
+        <ion-item routerLink="/users" routerDirection="root">
+          <ion-icon slot="start" name="people-outline"></ion-icon>
+          <ion-label>Usuários</ion-label>
+        </ion-item>
+      </ion-menu-toggle>
+    </ion-list>
+  </ion-content>
+</ion-menu>

--- a/frontend/src/app/shared/sidebar/sidebar.component.scss
+++ b/frontend/src/app/shared/sidebar/sidebar.component.scss
@@ -1,0 +1,3 @@
+ion-menu {
+  --width: 250px;
+}

--- a/frontend/src/app/shared/sidebar/sidebar.component.ts
+++ b/frontend/src/app/shared/sidebar/sidebar.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+
+@Component({
+  selector: 'app-sidebar',
+  standalone: true,
+  imports: [IonicModule],
+  templateUrl: './sidebar.component.html',
+  styleUrls: ['./sidebar.component.scss']
+})
+export class SidebarComponent {}

--- a/frontend/src/app/users/users.page.html
+++ b/frontend/src/app/users/users.page.html
@@ -1,3 +1,4 @@
+<app-header></app-header>
 <ion-content class="users-wrapper" fullscreen>
   <div class="users-container">
     <!-- Cabeçalho -->

--- a/frontend/src/app/users/users.page.ts
+++ b/frontend/src/app/users/users.page.ts
@@ -16,6 +16,7 @@ import { AuthService } from '../services/auth.service';
 import { UiService } from '../services/ui.service';
 import { EditUserModalComponent } from './components/edit-user-modal/edit-user-modal.component';
 import { AddUserModalComponent } from './components/add-user/add-user-modal.component';
+import { HeaderComponent } from '../shared/header/header.component';
 
 @Component({
   selector: 'app-users',
@@ -32,6 +33,7 @@ import { AddUserModalComponent } from './components/add-user/add-user-modal.comp
     IonCard,
     IonCardContent,
     IonBadge,
+    HeaderComponent,
     AddUserModalComponent,
     EditUserModalComponent,
   ],


### PR DESCRIPTION
## Summary
- implement global sidebar with IonMenu
- add header component with logout button
- include header on UsersPage
- show menu only when logged in

## Testing
- `npx ng lint` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_687101faffc08322ab7094fd55373355