### PR TITLE
Add frontend tests

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:4200',
+    supportFile: false,
+  },
+});

--- a/frontend/cypress/e2e/auth.cy.ts
+++ b/frontend/cypress/e2e/auth.cy.ts
@@ -1,0 +1,6 @@
+describe('Auth flow', () => {
+  it('should show login page', () => {
+    cy.visit('/login');
+    cy.contains('Login');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "lint": "ng lint"
+    "lint": "ng lint",
+    "e2e": "cypress run"
   },
   "private": true,
   "dependencies": {
@@ -52,6 +53,7 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.8.0"
+    "typescript": "~5.8.0",
+    "cypress": "^13.0.0"
   }
 }

--- a/frontend/src/app/auth/auth.page.spec.ts
+++ b/frontend/src/app/auth/auth.page.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+import { AuthPage } from './auth.page';
+import { AuthService } from '../services/auth.service';
+
+class AuthServiceMock {
+  login = jasmine.createSpy('login').and.resolveTo();
+  register = jasmine.createSpy('register').and.resolveTo();
+  isLoggedIn = () => false;
+}
+
+describe('AuthPage', () => {
+  let component: AuthPage;
+  let fixture: ComponentFixture<AuthPage>;
+  let auth: AuthServiceMock;
+
+  beforeEach(async () => {
+    auth = new AuthServiceMock();
+    await TestBed.configureTestingModule({
+      imports: [IonicModule, ReactiveFormsModule, RouterTestingModule, AuthPage],
+      providers: [{ provide: AuthService, useValue: auth }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AuthPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should submit login form', async () => {
+    component.form.setValue({ name: '', email: 'e@e.com', password: '123456' });
+    await component.submit();
+    expect(auth.login).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/core/interceptors/http-error.interceptor.spec.ts
+++ b/frontend/src/app/core/interceptors/http-error.interceptor.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { HttpErrorInterceptor } from './http-error.interceptor';
+import { ToastService } from '../../shared/toast.service';
+import { ErrorTranslatorService } from '../services/error-translator.service';
+
+class ToastMock {
+  error = jasmine.createSpy('error');
+}
+
+describe('HttpErrorInterceptor', () => {
+  let http: HttpClient;
+  let controller: HttpTestingController;
+  let toast: ToastMock;
+
+  beforeEach(() => {
+    toast = new ToastMock();
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        ErrorTranslatorService,
+        { provide: ToastService, useValue: toast },
+        { provide: HTTP_INTERCEPTORS, useClass: HttpErrorInterceptor, multi: true },
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  it('should show translated error message', () => {
+    http.get('/test').subscribe({ error: () => {} });
+    const req = controller.expectOne('/test');
+    req.flush({ internalCode: 'AUTH_001' }, { status: 400, statusText: 'Bad Request' });
+    expect(toast.error).toHaveBeenCalledWith('E-mail ou senha incorretos.');
+  });
+});

--- a/frontend/src/app/core/services/error-translator.service.spec.ts
+++ b/frontend/src/app/core/services/error-translator.service.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing';
+import { ErrorTranslatorService } from './error-translator.service';
+
+describe('ErrorTranslatorService', () => {
+  let service: ErrorTranslatorService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ErrorTranslatorService);
+  });
+
+  it('should translate known code', () => {
+    expect(service.translate('AUTH_001')).toBe('E-mail ou senha incorretos.');
+  });
+
+  it('should fallback for unknown', () => {
+    expect(service.translate('UNKNOWN')).toBe('Algo deu errado. Tente novamente.');
+  });
+});

--- a/frontend/src/app/services/auth.guard.spec.ts
+++ b/frontend/src/app/services/auth.guard.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { authGuard } from './auth.guard';
+import { AuthService } from './auth.service';
+
+describe('authGuard', () => {
+  it('should redirect when not logged in', () => {
+    const router = { navigateByUrl: jasmine.createSpy('navigateByUrl') } as any as Router;
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: { isLoggedIn: () => false } },
+        { provide: Router, useValue: router },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => authGuard({} as any, {} as any));
+    expect(result).toBeFalse();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/login');
+  });
+});

--- a/frontend/src/app/services/auth.service.spec.ts
+++ b/frontend/src/app/services/auth.service.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AuthService } from './auth.service';
+import { environment } from '../../environments/environment';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let http: HttpTestingController;
+  const base = environment.apiUrl;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AuthService],
+    });
+    service = TestBed.inject(AuthService);
+    http = TestBed.inject(HttpTestingController);
+    localStorage.clear();
+  });
+
+  it('should login and store token', async () => {
+    const token = 'jwt.token';
+    service.login('test@example.com', 'pass').then();
+    const req = http.expectOne(`${base}/auth/login`);
+    req.flush({ access_token: token });
+    expect(localStorage.getItem('token')).toBe(token);
+  });
+
+  it('should register user', async () => {
+    service.register('name', 'e@e.com', '123456').then();
+    const req = http.expectOne(`${base}/auth/register`);
+    expect(req.request.method).toBe('POST');
+  });
+
+  it('should detect logged in status', () => {
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    const token = `a.${btoa(JSON.stringify({ sub: 1, exp }))}.c`;
+    localStorage.setItem('token', token);
+    expect(service.isLoggedIn()).toBeTrue();
+  });
+
+  it('should return userId and token', () => {
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    const token = `a.${btoa(JSON.stringify({ sub: 2, exp }))}.c`;
+    localStorage.setItem('token', token);
+    expect(service.userId).toBe(2);
+    expect(service.user).toBe(2);
+  });
+});

--- a/frontend/src/app/users/components/add-user/add-user-modal.component.spec.ts
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.spec.ts
@@ -1,0 +1,39 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+import { AddUserModalComponent } from './add-user-modal.component';
+import { UserService } from '../../services/user.service';
+import { UiService } from '../../../core/services/ui.service';
+
+class UserServiceMock {
+  create = jasmine.createSpy('create').and.resolveTo({ id: 1, name: 'n', email: 'e' });
+  update = jasmine.createSpy('update').and.resolveTo({ id: 1, name: 'n', email: 'e' });
+}
+class UiServiceMock { toast() {} }
+
+describe('AddUserModalComponent', () => {
+  let component: AddUserModalComponent;
+  let fixture: ComponentFixture<AddUserModalComponent>;
+  let userService: UserServiceMock;
+
+  beforeEach(async () => {
+    userService = new UserServiceMock();
+    await TestBed.configureTestingModule({
+      imports: [IonicModule, ReactiveFormsModule, AddUserModalComponent],
+      providers: [
+        { provide: UserService, useValue: userService },
+        { provide: UiService, useClass: UiServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddUserModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create new user', async () => {
+    component.form.setValue({ name: 'n', email: 'e', password: '123456' });
+    await component.save();
+    expect(userService.create).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/users/pages/users.page.spec.ts
+++ b/frontend/src/app/users/pages/users.page.spec.ts
@@ -1,0 +1,44 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { IonicModule } from '@ionic/angular';
+import { FormsModule } from '@angular/forms';
+import { UsersPage } from './users.page';
+import { UserService, User } from '../services/user.service';
+import { AuthService } from '../../services/auth.service';
+import { UiService } from '../../core/services/ui.service';
+
+class UserServiceMock {
+  findAll = jasmine.createSpy('findAll').and.resolveTo([{ id:1,name:'n',email:'e'}]);
+  delete = jasmine.createSpy('delete').and.resolveTo();
+}
+class AuthServiceMock {
+  isLoggedIn = () => true;
+  userId = 1;
+  logout = jasmine.createSpy('logout');
+}
+class UiServiceMock { toast() {} }
+
+describe('UsersPage', () => {
+  let component: UsersPage;
+  let fixture: ComponentFixture<UsersPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [IonicModule, FormsModule, RouterTestingModule, UsersPage],
+      providers: [
+        { provide: UserService, useClass: UserServiceMock },
+        { provide: AuthService, useClass: AuthServiceMock },
+        { provide: UiService, useClass: UiServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UsersPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should load users on init', async () => {
+    await component.load();
+    expect(component.users.length).toBe(1);
+  });
+});

--- a/frontend/src/app/users/services/user.service.spec.ts
+++ b/frontend/src/app/users/services/user.service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { UserService } from './user.service';
+import { environment } from '../../../environments/environment';
+
+describe('UserService', () => {
+  let service: UserService;
+  let http: HttpTestingController;
+  const base = environment.apiUrl;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+    service = TestBed.inject(UserService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  it('should call findAll', () => {
+    service.findAll().then();
+    const req = http.expectOne(`${base}/users`);
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should call get', () => {
+    service.get(1).then();
+    const req = http.expectOne(`${base}/users/1`);
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should call create', () => {
+    service.create('a','b','c').then();
+    const req = http.expectOne(`${base}/users`);
+    expect(req.request.method).toBe('POST');
+  });
+
+  it('should call update', () => {
+    service.update(1,'n','e').then();
+    const req = http.expectOne(`${base}/users/1`);
+    expect(req.request.method).toBe('PUT');
+  });
+
+  it('should call delete', () => {
+    service.delete(1).then();
+    const req = http.expectOne(`${base}/users/1`);
+    expect(req.request.method).toBe('DELETE');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test specs for auth service, user service, error translator, http interceptor
- add basic component specs for auth page and users page
- add spec for add-user modal component and auth guard
- introduce Cypress config with example e2e test
- add `e2e` script and cypress dependency

## Testing
- `npm test --silent -- --watch=false` *(fails: No binary for Chrome)*
- `npm run e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68712eebf1008322aaa500778df7dc1d