### PR TITLE
Fix unit tests

### DIFF
--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   it('should create the app', async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
+      imports: [HttpClientTestingModule, AppComponent],
       providers: [provideRouter([])]
     }).compileComponents();
     

--- a/frontend/src/app/auth/auth.page.spec.ts
+++ b/frontend/src/app/auth/auth.page.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule, NavController } from '@ionic/angular';
 import { AuthPage } from './auth.page';
 import { AuthService } from '../services/auth.service';
 
@@ -20,7 +20,10 @@ describe('AuthPage', () => {
     auth = new AuthServiceMock();
     await TestBed.configureTestingModule({
       imports: [IonicModule, ReactiveFormsModule, RouterTestingModule, AuthPage],
-      providers: [{ provide: AuthService, useValue: auth }],
+      providers: [
+        { provide: AuthService, useValue: auth },
+        { provide: NavController, useValue: { navigateRoot: () => {}, navigateForward: () => {}, navigateBack: () => {} } },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AuthPage);

--- a/frontend/src/app/services/auth.service.spec.ts
+++ b/frontend/src/app/services/auth.service.spec.ts
@@ -20,16 +20,19 @@ describe('AuthService', () => {
 
   it('should login and store token', async () => {
     const token = 'jwt.token';
-    service.login('test@example.com', 'pass').then();
+    const promise = service.login('test@example.com', 'pass');
     const req = http.expectOne(`${base}/auth/login`);
     req.flush({ access_token: token });
+    await promise;
     expect(localStorage.getItem('token')).toBe(token);
   });
 
   it('should register user', async () => {
-    service.register('name', 'e@e.com', '123456').then();
+    const promise = service.register('name', 'e@e.com', '123456');
     const req = http.expectOne(`${base}/auth/register`);
     expect(req.request.method).toBe('POST');
+    req.flush({});
+    await promise;
   });
 
   it('should detect logged in status', () => {

--- a/frontend/src/app/users/components/add-user/add-user-modal.component.spec.ts
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.spec.ts
@@ -32,7 +32,7 @@ describe('AddUserModalComponent', () => {
   });
 
   it('should create new user', async () => {
-    component.form.setValue({ name: 'n', email: 'e', password: '123456' });
+    component.form.setValue({ name: 'n', email: 'e@e.com', password: '123456' });
     await component.save();
     expect(userService.create).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- include HttpClientTestingModule for app component test
- mock NavController in auth page test
- await async calls in auth service tests
- use valid email in AddUserModal test

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: ChromeHeadless requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6871386a69208322b44dde7dce69b199