### PR TITLE
Update Swagger docs

### DIFF
--- a/backend/src/application/dto/create-user.dto.ts
+++ b/backend/src/application/dto/create-user.dto.ts
@@ -1,12 +1,16 @@
 import { IsEmail, IsNotEmpty, MinLength, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateUserDto {
+  @ApiProperty({ example: 'John Doe' })
   @IsNotEmpty()
   name: string;
 
+  @ApiProperty({ example: 'john@example.com' })
   @IsEmail()
   email: string;
 
+  @ApiProperty({ example: 'P@ssw0rd!' })
   @MinLength(8)
   @Matches(/[^A-Za-z0-9]/, {
     message: 'password must contain at least one special character',

--- a/backend/src/application/dto/login.dto.ts
+++ b/backend/src/application/dto/login.dto.ts
@@ -1,9 +1,12 @@
 import { IsEmail, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
+  @ApiProperty({ example: 'john@example.com' })
   @IsEmail()
   email: string;
 
+  @ApiProperty({ example: 'P@ssw0rd!' })
   @IsString()
   password: string;
 }

--- a/backend/src/application/dto/update-user.dto.ts
+++ b/backend/src/application/dto/update-user.dto.ts
@@ -1,10 +1,13 @@
 import { IsEmail, IsOptional, MinLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateUserDto {
+  @ApiPropertyOptional({ example: 'John Doe' })
   @IsOptional()
   @MinLength(1)
   name?: string;
 
+  @ApiPropertyOptional({ example: 'john@example.com' })
   @IsOptional()
   @IsEmail()
   email?: string;

--- a/backend/src/interface/http/controllers/auth.controller.ts
+++ b/backend/src/interface/http/controllers/auth.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Post, Body, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
 import { AuthService } from '../../../infrastructure/services/auth.service';
 import { CreateUserUseCase } from '../../../application/use-cases/user/create-user.use-case';
 import { CreateUserDto } from '../../../application/dto/create-user.dto';
@@ -7,6 +8,7 @@ import { LoginDto } from '../../../application/dto/login.dto';
 import { LocalAuthGuard } from '../guards/local-auth.guard';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(
@@ -16,6 +18,7 @@ export class AuthController {
   ) {}
 
   @Post('register')
+  @ApiBody({ type: CreateUserDto })
   async register(@Body() dto: CreateUserDto) {
     const user = await this.createUser.execute(dto);
     const { password, ...result } = user;
@@ -24,11 +27,13 @@ export class AuthController {
 
   @UseGuards(LocalAuthGuard)
   @Post('login')
+  @ApiBody({ type: LoginDto })
   async login(@Request() req, @Body() dto: LoginDto) {
     return this.loginUseCase.execute(dto);
   }
 
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Post('profile')
   getProfile(@Request() req) {
     return req.user;

--- a/backend/src/interface/http/controllers/users.controller.ts
+++ b/backend/src/interface/http/controllers/users.controller.ts
@@ -8,6 +8,7 @@ import {
   Put,
   UseGuards,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
 import { CreateUserDto } from '../../../application/dto/create-user.dto';
 import { UpdateUserDto } from '../../../application/dto/update-user.dto';
 import { CreateUserUseCase } from '../../../application/use-cases/user/create-user.use-case';
@@ -17,6 +18,7 @@ import { ListUsersUseCase } from '../../../application/use-cases/user/list-users
 import { GetUserUseCase } from '../../../application/use-cases/user/get-user.use-case';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 
+@ApiTags('users')
 @Controller('users')
 export class UsersController {
   constructor(
@@ -28,29 +30,34 @@ export class UsersController {
   ) {}
 
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Get()
   findAll() {
     return this.listUsers.execute();
   }
 
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.getUser.execute(+id);
   }
 
   @Post()
+  @ApiBody({ type: CreateUserDto })
   create(@Body() dto: CreateUserDto) {
     return this.createUser.execute(dto);
   }
 
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Put(':id')
   update(@Param('id') id: string, @Body() dto: UpdateUserDto) {
     return this.updateUser.execute(+id, dto);
   }
 
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.deleteUser.execute(+id);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -15,9 +15,16 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setVersion('1.0')
+    .addBearerAuth()
     .build();
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup('api', app, document, {
+    swaggerOptions: {
+      persistAuthorization: true,
+      tagsSorter: 'alpha',
+      operationsSorter: 'method',
+    },
+  });
 
   await app.listen(process.env.PORT ?? 3000);
 }


### PR DESCRIPTION
## Summary
- document DTOs with example payloads
- expose Auth endpoints first in Swagger via tag sorting
- secure endpoints with `ApiBearerAuth`
- keep JWT token when browsing Swagger

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68715a04dc4c83229143f52cde5fae58