### PR TITLE
Implement server-side logout

### DIFF
--- a/backend/src/application/use-cases/auth/logout.use-case.spec.ts
+++ b/backend/src/application/use-cases/auth/logout.use-case.spec.ts
@@ -1,8 +1,15 @@
 import { LogoutUseCase } from './logout.use-case';
+import { ITokenBlacklistService } from '../../../domain/services/token-blacklist.service';
+import { JwtService } from '@nestjs/jwt';
 
 describe('LogoutUseCase', () => {
-  it('executes without error', () => {
-    const useCase = new LogoutUseCase();
-    expect(useCase.execute()).toBeUndefined();
+  it('adds token to blacklist', () => {
+    const blacklist: jest.Mocked<ITokenBlacklistService> = {
+      add: jest.fn(),
+      has: jest.fn(),
+    };
+    const useCase = new LogoutUseCase(blacklist, new JwtService({ secret: 't' }));
+    useCase.execute('token');
+    expect(blacklist.add).toHaveBeenCalled();
   });
 });

--- a/backend/src/application/use-cases/auth/logout.use-case.ts
+++ b/backend/src/application/use-cases/auth/logout.use-case.ts
@@ -1,9 +1,25 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ITokenBlacklistService } from '../../../domain/services/token-blacklist.service';
 
 @Injectable()
 export class LogoutUseCase {
-  // For JWT stateless auth, logout can be handled client-side or with token blacklist.
-  execute(): void {
-    // no-op
+  constructor(
+    @Inject('ITokenBlacklistService')
+    private readonly blacklist: ITokenBlacklistService,
+    private readonly jwt: JwtService,
+  ) {}
+
+  execute(token: string): void {
+    let ttl = 0;
+    try {
+      const decoded: any = this.jwt.decode(token, { json: true });
+      if (decoded?.exp) {
+        ttl = decoded.exp - Math.floor(Date.now() / 1000);
+      }
+    } catch (e) {
+      ttl = 0;
+    }
+    this.blacklist.add(token, ttl > 0 ? ttl : 0);
   }
 }

--- a/backend/src/domain/services/token-blacklist.service.ts
+++ b/backend/src/domain/services/token-blacklist.service.ts
@@ -1,0 +1,4 @@
+export interface ITokenBlacklistService {
+  add(token: string, ttlSeconds: number): void;
+  has(token: string): boolean;
+}

--- a/backend/src/infrastructure/modules/auth.module.ts
+++ b/backend/src/infrastructure/modules/auth.module.ts
@@ -10,6 +10,9 @@ import { JwtStrategy } from '../../interface/http/guards/jwt.strategy';
 import { JwtTokenService } from '../services/jwt.service';
 import { BcryptService } from '../services/bcrypt.service';
 import { LoginUseCase } from '../../application/use-cases/auth/login.use-case';
+import { LogoutUseCase } from '../../application/use-cases/auth/logout.use-case';
+import { JwtAuthGuard } from '../../interface/http/guards/jwt-auth.guard';
+import { TokenBlacklistService } from '../services/token-blacklist.service';
 
 @Module({
   imports: [
@@ -29,10 +32,14 @@ import { LoginUseCase } from '../../application/use-cases/auth/login.use-case';
     AuthService,
     LocalStrategy,
     JwtStrategy,
+    JwtAuthGuard,
     JwtTokenService,
     BcryptService,
+    TokenBlacklistService,
     { provide: 'ICryptoService', useExisting: BcryptService },
+    { provide: 'ITokenBlacklistService', useExisting: TokenBlacklistService },
     LoginUseCase,
+    LogoutUseCase,
   ],
 })
 export class AuthModule {}

--- a/backend/src/infrastructure/services/token-blacklist.service.ts
+++ b/backend/src/infrastructure/services/token-blacklist.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { ITokenBlacklistService } from '../../domain/services/token-blacklist.service';
+
+interface Entry {
+  expires: NodeJS.Timeout;
+}
+
+@Injectable()
+export class TokenBlacklistService implements ITokenBlacklistService {
+  private tokens = new Map<string, Entry>();
+
+  add(token: string, ttlSeconds: number): void {
+    if (ttlSeconds <= 0) ttlSeconds = 0;
+    if (this.tokens.has(token)) return;
+    const timeout = setTimeout(() => this.tokens.delete(token), ttlSeconds * 1000);
+    this.tokens.set(token, { expires: timeout });
+  }
+
+  has(token: string): boolean {
+    return this.tokens.has(token);
+  }
+}

--- a/backend/src/interface/http/controllers/auth.controller.ts
+++ b/backend/src/interface/http/controllers/auth.controller.ts
@@ -5,6 +5,7 @@ import { CreateUserUseCase } from '../../../application/use-cases/user/create-us
 import { CreateUserDto } from '../../../application/dto/create-user.dto';
 import { LoginUseCase } from '../../../application/use-cases/auth/login.use-case';
 import { LoginDto } from '../../../application/dto/login.dto';
+import { LogoutUseCase } from '../../../application/use-cases/auth/logout.use-case';
 import { LocalAuthGuard } from '../guards/local-auth.guard';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 
@@ -15,6 +16,7 @@ export class AuthController {
     private authService: AuthService,
     private createUser: CreateUserUseCase,
     private loginUseCase: LoginUseCase,
+    private logoutUseCase: LogoutUseCase,
   ) {}
 
   @Post('register')
@@ -30,6 +32,17 @@ export class AuthController {
   @ApiBody({ type: LoginDto })
   async login(@Request() req, @Body() dto: LoginDto) {
     return this.loginUseCase.execute(dto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Post('logout')
+  logout(@Request() req) {
+    const token = req.headers['authorization']?.replace('Bearer ', '');
+    if (token) {
+      this.logoutUseCase.execute(token);
+    }
+    return { success: true };
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/interface/http/guards/jwt-auth.guard.ts
+++ b/backend/src/interface/http/guards/jwt-auth.guard.ts
@@ -1,11 +1,30 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { ExtractJwt } from 'passport-jwt';
 import { AppException } from '../../../shared/exceptions/app.exception';
 import { ErrorCodes } from '../../../shared/exceptions/error-codes';
+import { ITokenBlacklistService } from '../../../domain/services/token-blacklist.service';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(
+    @Inject('ITokenBlacklistService')
+    private readonly blacklist: ITokenBlacklistService,
+  ) {
+    super();
+  }
+
   handleRequest(err: any, user: any, info: any, context: any, status?: any) {
+    const req = context.switchToHttp().getRequest();
+    const token = ExtractJwt.fromAuthHeaderAsBearerToken()(req);
+    if (token && this.blacklist.has(token)) {
+      throw new AppException(
+        ErrorCodes.AUTH.TOKEN_INVALID.code,
+        ErrorCodes.AUTH.TOKEN_INVALID.message,
+        401,
+      );
+    }
+
     if (err || !user) {
       if (info?.name === 'TokenExpiredError') {
         throw new AppException(

--- a/frontend/src/app/services/auth.service.spec.ts
+++ b/frontend/src/app/services/auth.service.spec.ts
@@ -35,6 +35,16 @@ describe('AuthService', () => {
     await promise;
   });
 
+  it('should logout and call backend', async () => {
+    localStorage.setItem('token', 'token');
+    const promise = service.logout();
+    const req = http.expectOne(`${base}/auth/logout`);
+    expect(req.request.method).toBe('POST');
+    req.flush({});
+    await promise;
+    expect(localStorage.getItem('token')).toBeNull();
+  });
+
   it('should detect logged in status', () => {
     const exp = Math.floor(Date.now() / 1000) + 60;
     const token = `a.${btoa(JSON.stringify({ sub: 1, exp }))}.c`;

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -26,8 +26,22 @@ export class AuthService {
     );
   }
 
-  logout() {
+  async logout(): Promise<void> {
+    const token = this.token;
     localStorage.removeItem('token');
+    if (token) {
+      try {
+        await firstValueFrom(
+          this.http.post(
+            `${this.base}/auth/logout`,
+            {},
+            { headers: { Authorization: `Bearer ${token}` } }
+          )
+        );
+      } catch {
+        // ignore errors
+      }
+    }
   }
 
   get token(): string | null {


### PR DESCRIPTION
## Summary
- blacklist JWT tokens on logout
- add blacklist service and use case
- protect routes using blacklisted tokens
- expose logout endpoint in AuthController
- call logout endpoint in frontend AuthService
- test logout and blacklist logic

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687161d372cc83229fc5ce36783415c1