### PR TITLE
Fix users endpoint auth guard

### DIFF
--- a/backend/src/application/use-cases/auth/logout.use-case.spec.ts
+++ b/backend/src/application/use-cases/auth/logout.use-case.spec.ts
@@ -13,6 +13,6 @@ describe('LogoutUseCase', () => {
       new JwtService({ secret: 't' }),
     );
     useCase.execute('token');
-    expect(blacklist.add.bind(blacklist)).toHaveBeenCalled();
+    expect(blacklist.add).toHaveBeenCalled();
   });
 });

--- a/backend/src/infrastructure/modules/auth.module.ts
+++ b/backend/src/infrastructure/modules/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -16,7 +16,7 @@ import { TokenBlacklistService } from '../services/token-blacklist.service';
 
 @Module({
   imports: [
-    UsersModule,
+    forwardRef(() => UsersModule),
     PassportModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
@@ -41,5 +41,6 @@ import { TokenBlacklistService } from '../services/token-blacklist.service';
     LoginUseCase,
     LogoutUseCase,
   ],
+  exports: [JwtAuthGuard, TokenBlacklistService, 'ITokenBlacklistService'],
 })
 export class AuthModule {}

--- a/backend/src/infrastructure/modules/users.module.ts
+++ b/backend/src/infrastructure/modules/users.module.ts
@@ -1,5 +1,6 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from './auth.module';
 import { User } from '../../domain/entities/user.entity';
 import { UserOrmRepository } from '../database/postgres/user.orm.repository';
 import { CreateUserUseCase } from '../../application/use-cases/user/create-user.use-case';
@@ -11,7 +12,7 @@ import { BcryptService } from '../services/bcrypt.service';
 import { UsersController } from '../../interface/http/controllers/users.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), forwardRef(() => AuthModule)],
   controllers: [UsersController],
   providers: [
     UserOrmRepository,


### PR DESCRIPTION
## Summary
- export blacklist service so `JwtAuthGuard` can resolve its dependency
- import `AuthModule` in `UsersModule`
- fix failing logout use case spec

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6872ac2a9de8832299e665495d1728b3