### PR TITLE
Add global redirect guard

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { authGuard } from './services/auth.guard';
+import { redirectGuard } from './services/redirect.guard';
 
 export const routes: Routes = [
   {
@@ -18,7 +19,11 @@ export const routes: Routes = [
   },
   {
     path: '',
-    redirectTo: 'login',
     pathMatch: 'full',
+    canActivate: [redirectGuard],
+  },
+  {
+    path: '**',
+    canActivate: [redirectGuard],
   },
 ];

--- a/frontend/src/app/services/redirect.guard.spec.ts
+++ b/frontend/src/app/services/redirect.guard.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { redirectGuard } from './redirect.guard';
+import { AuthService } from './auth.service';
+
+describe('redirectGuard', () => {
+  it('should redirect to login when not logged in', () => {
+    const router = { navigateByUrl: jasmine.createSpy('navigateByUrl') } as any as Router;
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: { isLoggedIn: () => false } },
+        { provide: Router, useValue: router },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => redirectGuard({} as any, {} as any));
+    expect(result).toBeFalse();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/login');
+  });
+
+  it('should redirect to users when logged in', () => {
+    const router = { navigateByUrl: jasmine.createSpy('navigateByUrl') } as any as Router;
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: { isLoggedIn: () => true } },
+        { provide: Router, useValue: router },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => redirectGuard({} as any, {} as any));
+    expect(result).toBeFalse();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/users');
+  });
+});

--- a/frontend/src/app/services/redirect.guard.ts
+++ b/frontend/src/app/services/redirect.guard.ts
@@ -1,0 +1,11 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const redirectGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  const target = auth.isLoggedIn() ? '/users' : '/login';
+  router.navigateByUrl(target);
+  return false;
+};


### PR DESCRIPTION
## Summary
- add a redirect guard to send unknown routes to `/login` or `/users`
- route root path and wildcard path through the new guard
- test redirect guard behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874f9716b748322984a692c0ba82704