### PR TITLE
Fix missing SCSS in production build

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -28,6 +28,9 @@
             ],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
+            "stylePreprocessorOptions": {
+              "includePaths": ["src"]
+            },
             "assets": [
               {
                 "glob": "**/*",
@@ -102,6 +105,9 @@
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",
+            "stylePreprocessorOptions": {
+              "includePaths": ["src"]
+            },
             "assets": [
               {
                 "glob": "**/*",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,6 +49,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
         "puppeteer": "^24.12.1",
+        "sass": "^1.89.2",
         "typescript": "~5.8.0"
       }
     },
@@ -213,6 +214,27 @@
         "tailwindcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/sass": {
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.88.0.tgz",
+      "integrity": "sha512-sF6TWQqjFvr4JILXzG4ucGOLELkESHL+I5QJhh7CNaE+Yge0SI+ehCatsXhJ7ymU1hAFcIS3/PBpjdIbXoyVbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
@@ -500,6 +522,27 @@
         "vitest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/build/node_modules/sass": {
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.88.0.tgz",
+      "integrity": "sha512-sF6TWQqjFvr4JILXzG4ucGOLELkESHL+I5QJhh7CNaE+Yge0SI+ehCatsXhJ7ymU1hAFcIS3/PBpjdIbXoyVbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/@angular/cli": {
@@ -16405,9 +16448,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.88.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.88.0.tgz",
-      "integrity": "sha512-sF6TWQqjFvr4JILXzG4ucGOLELkESHL+I5QJhh7CNaE+Yge0SI+ehCatsXhJ7ymU1hAFcIS3/PBpjdIbXoyVbg==",
+      "version": "1.89.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
+      "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "puppeteer": "^24.12.1",
     "typescript": "~5.8.0",
-    "cypress": "^13.0.0"
+    "cypress": "^13.0.0",
+    "sass": "^1.89.2"
   }
 }


### PR DESCRIPTION
## Summary
- add `sass` dev dependency to ensure SCSS compilation
- configure `stylePreprocessorOptions` so Angular resolves SCSS imports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874ffd695c08322bfb68fe436878310