### PR TITLE
Remove IonicModule usage

### DIFF
--- a/frontend/src/app/auth/auth.page.spec.ts
+++ b/frontend/src/app/auth/auth.page.spec.ts
@@ -1,7 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { IonicModule, NavController } from '@ionic/angular';
+import { NavController } from '@ionic/angular';
+import { provideIonicAngular } from '@ionic/angular/standalone';
 import { AuthPage } from './auth.page';
 import { AuthService } from '../services/auth.service';
 
@@ -19,8 +20,9 @@ describe('AuthPage', () => {
   beforeEach(async () => {
     auth = new AuthServiceMock();
     await TestBed.configureTestingModule({
-      imports: [IonicModule, ReactiveFormsModule, RouterTestingModule, AuthPage],
+      imports: [ReactiveFormsModule, RouterTestingModule, AuthPage],
       providers: [
+        provideIonicAngular(),
         { provide: AuthService, useValue: auth },
         { provide: NavController, useValue: { navigateRoot: () => {}, navigateForward: () => {}, navigateBack: () => {} } },
       ],

--- a/frontend/src/app/shared/confirm-modal/confirm-modal.component.ts
+++ b/frontend/src/app/shared/confirm-modal/confirm-modal.component.ts
@@ -1,11 +1,30 @@
 import { Component } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
+import {
+  IonModal,
+  IonCard,
+  IonCardHeader,
+  IonCardTitle,
+  IonButtons,
+  IonButton,
+  IonIcon,
+  IonCardContent,
+} from '@ionic/angular/standalone';
 import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-confirm-modal',
   standalone: true,
-  imports: [IonicModule, CommonModule],
+  imports: [
+    IonModal,
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonButtons,
+    IonButton,
+    IonIcon,
+    IonCardContent,
+    CommonModule,
+  ],
   templateUrl: './confirm-modal.component.html',
   styleUrls: ['./confirm-modal.component.scss'],
 })

--- a/frontend/src/app/shared/header/header.component.ts
+++ b/frontend/src/app/shared/header/header.component.ts
@@ -1,12 +1,28 @@
 import { Component } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
+import {
+  IonHeader,
+  IonToolbar,
+  IonButtons,
+  IonMenuButton,
+  IonTitle,
+  IonButton,
+  IonIcon,
+} from '@ionic/angular/standalone';
 import { Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [IonicModule],
+  imports: [
+    IonHeader,
+    IonToolbar,
+    IonButtons,
+    IonMenuButton,
+    IonTitle,
+    IonButton,
+    IonIcon,
+  ],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss']
 })

--- a/frontend/src/app/shared/sidebar/sidebar.component.ts
+++ b/frontend/src/app/shared/sidebar/sidebar.component.ts
@@ -1,10 +1,34 @@
 import { Component } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
+import {
+  IonMenu,
+  IonContent,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonList,
+  IonMenuToggle,
+  IonItem,
+  IonIcon,
+  IonLabel,
+} from '@ionic/angular/standalone';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-sidebar',
   standalone: true,
-  imports: [IonicModule],
+  imports: [
+    IonMenu,
+    IonContent,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonList,
+    IonMenuToggle,
+    IonItem,
+    IonIcon,
+    IonLabel,
+    RouterModule,
+  ],
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.scss']
 })

--- a/frontend/src/app/shared/table/table.component.ts
+++ b/frontend/src/app/shared/table/table.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { IonicModule } from '@ionic/angular';
+import { IonBadge, IonButton, IonIcon } from '@ionic/angular/standalone';
 
 export interface ColumnDefinition {
   header: string;
@@ -10,7 +10,7 @@ export interface ColumnDefinition {
 @Component({
   selector: 'app-table',
   standalone: true,
-  imports: [CommonModule, IonicModule],
+  imports: [CommonModule, IonBadge, IonButton, IonIcon],
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.scss'],
 })

--- a/frontend/src/app/users/components/add-user/add-user-modal.component.spec.ts
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { IonicModule } from '@ionic/angular';
+import { provideIonicAngular } from '@ionic/angular/standalone';
 import { AddUserModalComponent } from './add-user-modal.component';
 import { UserService } from '../../services/user.service';
 import { UiService } from '../../../core/services/ui.service';
@@ -19,8 +19,9 @@ describe('AddUserModalComponent', () => {
   beforeEach(async () => {
     userService = new UserServiceMock();
     await TestBed.configureTestingModule({
-      imports: [IonicModule, ReactiveFormsModule, AddUserModalComponent],
+      imports: [ReactiveFormsModule, AddUserModalComponent],
       providers: [
+        provideIonicAngular(),
         { provide: UserService, useValue: userService },
         { provide: UiService, useClass: UiServiceMock },
       ],

--- a/frontend/src/app/users/components/add-user/add-user-modal.component.ts
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.ts
@@ -1,5 +1,16 @@
 import { Component, EventEmitter, Output } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
+import {
+  IonModal,
+  IonCard,
+  IonCardHeader,
+  IonCardTitle,
+  IonButtons,
+  IonButton,
+  IonIcon,
+  IonCardContent,
+  IonItem,
+  IonInput,
+} from '@ionic/angular/standalone';
 import { CommonModule } from '@angular/common';
 import {
   ReactiveFormsModule,
@@ -13,7 +24,20 @@ import { UiService } from '../../../core/services/ui.service';
 @Component({
   selector: 'app-add-user-modal',
   standalone: true,
-  imports: [IonicModule, CommonModule, ReactiveFormsModule],
+  imports: [
+    IonModal,
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonButtons,
+    IonButton,
+    IonIcon,
+    IonCardContent,
+    IonItem,
+    IonInput,
+    CommonModule,
+    ReactiveFormsModule,
+  ],
   templateUrl: './add-user-modal.component.html',
   styleUrls: ['./add-user-modal.component.scss'],
 })

--- a/frontend/src/app/users/components/user-stats/user-stats.component.ts
+++ b/frontend/src/app/users/components/user-stats/user-stats.component.ts
@@ -1,12 +1,12 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { IonicModule } from '@ionic/angular';
+import { IonCard, IonCardContent } from '@ionic/angular/standalone';
 import { User } from '../../services/user.service';
 
 @Component({
   selector: 'app-user-stats',
   standalone: true,
-  imports: [CommonModule, IonicModule],
+  imports: [CommonModule, IonCard, IonCardContent],
   templateUrl: './user-stats.component.html',
   styleUrls: ['./user-stats.component.scss'],
 })

--- a/frontend/src/app/users/components/users-table/users-table.component.ts
+++ b/frontend/src/app/users/components/users-table/users-table.component.ts
@@ -1,13 +1,13 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { IonicModule } from '@ionic/angular';
+import { IonCard, IonCardContent } from '@ionic/angular/standalone';
 import { TableComponent } from '../../../shared/table/table.component';
 import { User } from '../../services/user.service';
 
 @Component({
   selector: 'app-users-table',
   standalone: true,
-  imports: [CommonModule, IonicModule, TableComponent],
+  imports: [CommonModule, IonCard, IonCardContent, TableComponent],
   templateUrl: './users-table.component.html',
   styleUrls: ['./users-table.component.scss'],
 })

--- a/frontend/src/app/users/pages/users.page.spec.ts
+++ b/frontend/src/app/users/pages/users.page.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { IonicModule } from '@ionic/angular';
+import { provideIonicAngular } from '@ionic/angular/standalone';
 import { FormsModule } from '@angular/forms';
 import { UsersPage } from './users.page';
 import { UserService, User } from '../services/user.service';
@@ -24,8 +24,9 @@ describe('UsersPage', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [IonicModule, FormsModule, RouterTestingModule, UsersPage],
+      imports: [FormsModule, RouterTestingModule, UsersPage],
       providers: [
+        provideIonicAngular(),
         { provide: UserService, useClass: UserServiceMock },
         { provide: AuthService, useClass: AuthServiceMock },
         { provide: UiService, useClass: UiServiceMock },


### PR DESCRIPTION
## Summary
- convert Ionic components to standalone imports
- refactor tests to use `provideIonicAngular`

## Testing
- `npm test --silent -- --no-watch --no-progress`
- `npm run lint` *(fails: prefer-inject rule)*

------
https://chatgpt.com/codex/tasks/task_e_687668b317d4832281690762ebb6de9e