### PR TITLE
Implement global error interceptor

### DIFF
--- a/frontend/src/app/core/interceptors/http-error.interceptor.ts
+++ b/frontend/src/app/core/interceptors/http-error.interceptor.ts
@@ -14,9 +14,12 @@ import { ErrorTranslatorService } from '../services/error-translator.service';
 export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
+      const translator = inject(ErrorTranslatorService);
+      const toast = inject(ToastService);
+      const userMsg = error?.error?.userMessage;
       const code = error?.error?.internalCode;
-      const message = inject(ErrorTranslatorService).translate(code);
-      inject(ToastService).error(message);
+      const message = userMsg || translator.translate(code);
+      toast.error(message);
       return throwError(() => error);
     })
   );


### PR DESCRIPTION
## Summary
- adapt http error interceptor to use `userMessage` from API responses

## Testing
- `npm test` *(fails: Chrome disconnected)*

------
https://chatgpt.com/codex/tasks/task_e_68767181346c8322ad791ffa8202f43c