### PR TITLE
Fix production API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This repository contains a basic NestJS backend with authentication, a simple Io
 1. Copy `.env.example` to `.env` inside `backend` and adjust settings.
 2. Run `docker-compose up` to start PostgreSQL, the backend and the frontend.
 3. Backend Swagger docs available at `http://localhost:3000/api`.
-4. Frontend available at `http://localhost:4200`.
+4. Frontend available at `http://localhost:4200` when running with `npm start`.
+   When using Docker the frontend container communicates with the backend via
+   the `backend` service name, so the production build points to
+   `http://backend:3000` internally.
 
 ## Features
 

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,9 @@
+// Production environment used inside the Docker container
+// The frontend runs in its own container and communicates with the
+// backend service via the Docker network.  Using "localhost" here would
+// resolve to the nginx container itself, so we point to the "backend"
+// service name defined in docker-compose instead.
 export const environment = {
   production: true,
-  apiUrl: 'http://localhost:3000',
+  apiUrl: 'http://backend:3000',
 };


### PR DESCRIPTION
## Summary
- point production build to the `backend` service
- document how the frontend container reaches the API

## Testing
- `npm test --silent` in `backend`
- `npm test` in `frontend` *(fails: Disconnected Client from CONNECTED state)*

------
https://chatgpt.com/codex/tasks/task_e_6877abd54be48322abf4d3d884632726