### PR TITLE
Implement custom toast component

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -13,4 +13,5 @@
   <ng-template #basic>
     <ion-router-outlet></ion-router-outlet>
   </ng-template>
+  <app-toast></app-toast>
 </ion-app>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@ionic/angular/standalone';
 import { SidebarComponent } from './shared/sidebar/sidebar.component';
 import { AuthService } from './services/auth.service';
+import { ToastComponent } from './shared/toast/toast.component';
 
 @Component({
   selector: 'app-root',
@@ -18,6 +19,7 @@ import { AuthService } from './services/auth.service';
     IonRouterOutlet,
     IonSplitPane,
     SidebarComponent,
+    ToastComponent,
   ],
 })
 export class AppComponent {

--- a/frontend/src/app/core/services/ui.service.ts
+++ b/frontend/src/app/core/services/ui.service.ts
@@ -1,24 +1,19 @@
 import { Injectable } from '@angular/core';
-import { AlertController, ToastController } from '@ionic/angular';
+import { AlertController } from '@ionic/angular';
+import { ToastService } from '../../shared/toast.service';
 
 @Injectable({ providedIn: 'root' })
 export class UiService {
   constructor(
-    private toastCtrl: ToastController,
+    private toastSvc: ToastService,
     private alertCtrl: AlertController
   ) {}
 
-  async toast(
+  toast(
     message: string,
     color: 'success' | 'danger' | 'warning' | 'primary' = 'primary'
   ) {
-    const toast = await this.toastCtrl.create({
-      message,
-      duration: 2000,
-      color,
-      position: 'bottom',
-    });
-    await toast.present();
+    this.toastSvc.show(message, color);
   }
 
   async confirm(message: string): Promise<boolean> {

--- a/frontend/src/app/shared/toast.service.ts
+++ b/frontend/src/app/shared/toast.service.ts
@@ -1,27 +1,37 @@
 import { Injectable } from '@angular/core';
-import { ToastController } from '@ionic/angular';
+import { Subject } from 'rxjs';
+
+export interface ToastMessage {
+  id: number;
+  message: string;
+  color: 'success' | 'danger' | 'warning' | 'primary';
+  duration?: number;
+}
 
 @Injectable({ providedIn: 'root' })
 export class ToastService {
-  constructor(private toastController: ToastController) {}
+  private counter = 0;
+  private toastSubject = new Subject<ToastMessage>();
+  toast$ = this.toastSubject.asObservable();
 
-  async error(message: string) {
-    const toast = await this.toastController.create({
+  show(
+    message: string,
+    color: 'success' | 'danger' | 'warning' | 'primary' = 'primary',
+    duration = 2000
+  ) {
+    this.toastSubject.next({
+      id: this.counter++,
       message,
-      duration: 3000,
-      color: 'danger',
-      position: 'bottom',
+      color,
+      duration,
     });
-    toast.present();
   }
 
-  async success(message: string) {
-    const toast = await this.toastController.create({
-      message,
-      duration: 2000,
-      color: 'success',
-      position: 'bottom',
-    });
-    toast.present();
+  success(message: string, duration = 2000) {
+    this.show(message, 'success', duration);
+  }
+
+  error(message: string, duration = 3000) {
+    this.show(message, 'danger', duration);
   }
 }

--- a/frontend/src/app/shared/toast/toast.component.html
+++ b/frontend/src/app/shared/toast/toast.component.html
@@ -1,0 +1,9 @@
+<div class="toast-container">
+  <div
+    *ngFor="let t of toasts"
+    class="toast"
+    [ngClass]="t.color"
+  >
+    {{ t.message }}
+  </div>
+</div>

--- a/frontend/src/app/shared/toast/toast.component.scss
+++ b/frontend/src/app/shared/toast/toast.component.scss
@@ -1,0 +1,34 @@
+.toast-container {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1000;
+}
+
+.toast {
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  color: #fff;
+  min-width: 200px;
+  text-align: center;
+}
+
+.toast.success {
+  background-color: var(--ion-color-success, #10dc60);
+}
+
+.toast.danger {
+  background-color: var(--ion-color-danger, #eb445a);
+}
+
+.toast.warning {
+  background-color: var(--ion-color-warning, #ffc409);
+}
+
+.toast.primary {
+  background-color: var(--ion-color-primary, #3880ff);
+}

--- a/frontend/src/app/shared/toast/toast.component.ts
+++ b/frontend/src/app/shared/toast/toast.component.ts
@@ -1,0 +1,31 @@
+import { Component, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { ToastService, ToastMessage } from '../toast.service';
+
+@Component({
+  selector: 'app-toast',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './toast.component.html',
+  styleUrls: ['./toast.component.scss'],
+})
+export class ToastComponent implements OnDestroy {
+  toasts: ToastMessage[] = [];
+  private sub: Subscription;
+
+  constructor(private toastService: ToastService) {
+    this.sub = this.toastService.toast$.subscribe((toast) => {
+      this.toasts.push(toast);
+      setTimeout(() => this.remove(toast.id), toast.duration ?? 2000);
+    });
+  }
+
+  remove(id: number) {
+    this.toasts = this.toasts.filter((t) => t.id !== id);
+  }
+
+  ngOnDestroy() {
+    this.sub.unsubscribe();
+  }
+}


### PR DESCRIPTION
## Summary
- add a ToastComponent to handle app notifications
- rework ToastService to provide toast events
- update UiService to use the new ToastService
- register the toast component globally in AppComponent

## Testing
- `npm test --silent -- --watch=false` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6877d9e4f178832289d8d11efc260f60