### PR TITLE
Add form error messages for auth and user modals

### DIFF
--- a/frontend/src/app/auth/auth.page.html
+++ b/frontend/src/app/auth/auth.page.html
@@ -30,6 +30,15 @@
             labelPlacement="floating"
           ></ion-input>
         </ion-item>
+        <ion-text
+          color="danger"
+          class="error-message"
+          *ngIf="mode === 'register' && form.get('name')?.touched && form.get('name')?.errors"
+        >
+          <small *ngIf="form.get('name')?.errors?.['required']">
+            Nome é obrigatório.
+          </small>
+        </ion-text>
 
         <ion-item lines="full">
           <ion-icon slot="start" name="mail-outline"></ion-icon>
@@ -42,6 +51,18 @@
             required
           ></ion-input>
         </ion-item>
+        <ion-text
+          color="danger"
+          class="error-message"
+          *ngIf="form.get('email')?.touched && form.get('email')?.errors"
+        >
+          <small *ngIf="form.get('email')?.errors?.['required']">
+            Email é obrigatório.
+          </small>
+          <small *ngIf="form.get('email')?.errors?.['email']">
+            Email inválido.
+          </small>
+        </ion-text>
 
         <ion-item lines="full">
           <ion-icon slot="start" name="lock-closed-outline"></ion-icon>
@@ -66,6 +87,21 @@
             ></ion-icon>
           </ion-button>
         </ion-item>
+        <ion-text
+          color="danger"
+          class="error-message"
+          *ngIf="form.get('password')?.touched && form.get('password')?.errors"
+        >
+          <small *ngIf="form.get('password')?.errors?.['required']">
+            Senha é obrigatória.
+          </small>
+          <small *ngIf="form.get('password')?.errors?.['minlength']">
+            Senha deve ter ao menos 8 caracteres.
+          </small>
+          <small *ngIf="form.get('password')?.errors?.['pattern']">
+            Senha deve conter ao menos um caractere especial.
+          </small>
+        </ion-text>
 
         <ion-button expand="block" class="btn-primary" type="submit">
           {{ mode === 'login' ? 'Entrar' : 'Cadastrar' }}

--- a/frontend/src/app/auth/auth.page.scss
+++ b/frontend/src/app/auth/auth.page.scss
@@ -81,6 +81,12 @@
       font-size: var(--ion-font-size-md);
     }
   }
+
+  .error-message {
+    margin: 0.25rem 0 0 0.5rem;
+    font-size: 0.75rem;
+    color: var(--ion-color-danger);
+  }
 }
 
 /* Link de registro abaixo do botão */

--- a/frontend/src/app/auth/auth.page.ts
+++ b/frontend/src/app/auth/auth.page.ts
@@ -15,6 +15,7 @@ import {
   IonIcon,
   IonInput,
   IonItem,
+  IonText,
   LoadingController,
   NavController,
 } from '@ionic/angular/standalone';
@@ -32,6 +33,7 @@ import { ErrorTranslatorService } from '../core/services/error-translator.servic
     IonItem,
     IonInput,
     IonIcon,
+    IonText,
     IonButton,
   ],
   templateUrl: './auth.page.html',

--- a/frontend/src/app/users/components/add-user/add-user-modal.component.html
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.html
@@ -27,6 +27,15 @@
               labelPlacement="floating"
             ></ion-input>
           </ion-item>
+          <ion-text
+            color="danger"
+            class="error-message"
+            *ngIf="form.get('name')?.touched && form.get('name')?.errors"
+          >
+            <small *ngIf="form.get('name')?.errors?.['required']">
+              Nome é obrigatório.
+            </small>
+          </ion-text>
 
           <ion-item lines="none">
             <ion-input
@@ -37,6 +46,18 @@
               autocomplete="off"
             ></ion-input>
           </ion-item>
+          <ion-text
+            color="danger"
+            class="error-message"
+            *ngIf="form.get('email')?.touched && form.get('email')?.errors"
+          >
+            <small *ngIf="form.get('email')?.errors?.['required']">
+              Email é obrigatório.
+            </small>
+            <small *ngIf="form.get('email')?.errors?.['email']">
+              Email inválido.
+            </small>
+          </ion-text>
 
           <ion-item lines="none" *ngIf="!editing">
             <ion-input
@@ -47,6 +68,21 @@
               autocomplete="off"
             ></ion-input>
           </ion-item>
+          <ion-text
+            *ngIf="!editing && form.get('password')?.touched && form.get('password')?.errors"
+            color="danger"
+            class="error-message"
+          >
+            <small *ngIf="form.get('password')?.errors?.['required']">
+              Senha é obrigatória.
+            </small>
+            <small *ngIf="form.get('password')?.errors?.['minlength']">
+              Senha deve ter ao menos 8 caracteres.
+            </small>
+            <small *ngIf="form.get('password')?.errors?.['pattern']">
+              Senha deve conter ao menos um caractere especial.
+            </small>
+          </ion-text>
 
           <ion-button
             expand="block"

--- a/frontend/src/app/users/components/add-user/add-user-modal.component.scss
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.scss
@@ -38,6 +38,12 @@ ion-card-header {
     font-size: 1rem;
   }
 
+  .error-message {
+    margin: 0.25rem 0 0 0.5rem;
+    font-size: 0.75rem;
+    color: var(--ion-color-danger);
+  }
+
   .save-button {
     margin-top: 0.5rem;
     font-weight: 600;

--- a/frontend/src/app/users/components/add-user/add-user-modal.component.ts
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.ts
@@ -10,6 +10,7 @@ import {
   IonCardContent,
   IonItem,
   IonInput,
+  IonText,
 } from '@ionic/angular/standalone';
 import { CommonModule } from '@angular/common';
 import {
@@ -36,6 +37,7 @@ import { ErrorTranslatorService } from '../../../core/services/error-translator.
     IonCardContent,
     IonItem,
     IonInput,
+    IonText,
     CommonModule,
     ReactiveFormsModule,
   ],


### PR DESCRIPTION
## Summary
- show validation errors on login/register forms
- display error messages on user add/edit form
- style error text

## Testing
- `npm install` in `frontend`
- `npm test` *(fails: Disconnected Client disconnected from CONNECTED state)*

------
https://chatgpt.com/codex/tasks/task_e_6877e030fc948322b35374944fcaf763