### PR TITLE
Refactor form validation error handling

### DIFF
--- a/frontend/src/app/auth/auth.page.html
+++ b/frontend/src/app/auth/auth.page.html
@@ -30,15 +30,10 @@
             labelPlacement="floating"
           ></ion-input>
         </ion-item>
-        <ion-text
-          color="danger"
-          class="error-message"
-          *ngIf="mode === 'register' && form.get('name')?.touched && form.get('name')?.errors"
-        >
-          <small *ngIf="form.get('name')?.errors?.['required']">
-            Nome é obrigatório.
-          </small>
-        </ion-text>
+        <app-form-error
+          *ngIf="mode === 'register'"
+          [control]="form.get('name')"
+        ></app-form-error>
 
         <ion-item lines="full">
           <ion-icon slot="start" name="mail-outline"></ion-icon>
@@ -51,18 +46,7 @@
             required
           ></ion-input>
         </ion-item>
-        <ion-text
-          color="danger"
-          class="error-message"
-          *ngIf="form.get('email')?.touched && form.get('email')?.errors"
-        >
-          <small *ngIf="form.get('email')?.errors?.['required']">
-            Email é obrigatório.
-          </small>
-          <small *ngIf="form.get('email')?.errors?.['email']">
-            Email inválido.
-          </small>
-        </ion-text>
+        <app-form-error [control]="form.get('email')"></app-form-error>
 
         <ion-item lines="full">
           <ion-icon slot="start" name="lock-closed-outline"></ion-icon>
@@ -87,21 +71,7 @@
             ></ion-icon>
           </ion-button>
         </ion-item>
-        <ion-text
-          color="danger"
-          class="error-message"
-          *ngIf="form.get('password')?.touched && form.get('password')?.errors"
-        >
-          <small *ngIf="form.get('password')?.errors?.['required']">
-            Senha é obrigatória.
-          </small>
-          <small *ngIf="form.get('password')?.errors?.['minlength']">
-            Senha deve ter ao menos 8 caracteres.
-          </small>
-          <small *ngIf="form.get('password')?.errors?.['pattern']">
-            Senha deve conter ao menos um caractere especial.
-          </small>
-        </ion-text>
+        <app-form-error [control]="form.get('password')"></app-form-error>
 
         <ion-button expand="block" class="btn-primary" type="submit">
           {{ mode === 'login' ? 'Entrar' : 'Cadastrar' }}

--- a/frontend/src/app/auth/auth.page.ts
+++ b/frontend/src/app/auth/auth.page.ts
@@ -15,12 +15,12 @@ import {
   IonIcon,
   IonInput,
   IonItem,
-  IonText,
   LoadingController,
   NavController,
 } from '@ionic/angular/standalone';
 import { UiService } from '../core/services/ui.service';
 import { ErrorTranslatorService } from '../core/services/error-translator.service';
+import { FormErrorComponent } from '../shared/form-error/form-error.component';
 
 @Component({
   selector: 'app-auth',
@@ -33,8 +33,8 @@ import { ErrorTranslatorService } from '../core/services/error-translator.servic
     IonItem,
     IonInput,
     IonIcon,
-    IonText,
     IonButton,
+    FormErrorComponent,
   ],
   templateUrl: './auth.page.html',
   styleUrls: ['./auth.page.scss'],

--- a/frontend/src/app/shared/form-error/form-error.component.html
+++ b/frontend/src/app/shared/form-error/form-error.component.html
@@ -1,0 +1,3 @@
+<ion-text color="danger" class="error-message" *ngIf="errorMessage">
+  <small>{{ errorMessage }}</small>
+</ion-text>

--- a/frontend/src/app/shared/form-error/form-error.component.scss
+++ b/frontend/src/app/shared/form-error/form-error.component.scss
@@ -1,0 +1,5 @@
+.error-message {
+  margin: 0.25rem 0 0 0.5rem;
+  font-size: 0.75rem;
+  color: var(--ion-color-danger);
+}

--- a/frontend/src/app/shared/form-error/form-error.component.ts
+++ b/frontend/src/app/shared/form-error/form-error.component.ts
@@ -1,0 +1,36 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+import { IonText } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-form-error',
+  standalone: true,
+  imports: [CommonModule, IonText],
+  templateUrl: './form-error.component.html',
+  styleUrls: ['./form-error.component.scss'],
+})
+export class FormErrorComponent {
+  @Input() control: AbstractControl | null | undefined;
+
+  get errorMessage(): string | null {
+    const c = this.control;
+    if (!c || !c.touched || !c.errors) {
+      return null;
+    }
+    const errors: ValidationErrors = c.errors;
+    if (errors['required']) {
+      return 'Campo obrigatório.';
+    }
+    if (errors['email']) {
+      return 'Email inválido.';
+    }
+    if (errors['minlength']) {
+      return `Deve ter ao menos ${errors['minlength'].requiredLength} caracteres.`;
+    }
+    if (errors['pattern']) {
+      return 'Formato inválido.';
+    }
+    return null;
+  }
+}

--- a/frontend/src/app/users/components/add-user/add-user-modal.component.html
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.html
@@ -27,15 +27,7 @@
               labelPlacement="floating"
             ></ion-input>
           </ion-item>
-          <ion-text
-            color="danger"
-            class="error-message"
-            *ngIf="form.get('name')?.touched && form.get('name')?.errors"
-          >
-            <small *ngIf="form.get('name')?.errors?.['required']">
-              Nome é obrigatório.
-            </small>
-          </ion-text>
+          <app-form-error [control]="form.get('name')"></app-form-error>
 
           <ion-item lines="none">
             <ion-input
@@ -46,18 +38,7 @@
               autocomplete="off"
             ></ion-input>
           </ion-item>
-          <ion-text
-            color="danger"
-            class="error-message"
-            *ngIf="form.get('email')?.touched && form.get('email')?.errors"
-          >
-            <small *ngIf="form.get('email')?.errors?.['required']">
-              Email é obrigatório.
-            </small>
-            <small *ngIf="form.get('email')?.errors?.['email']">
-              Email inválido.
-            </small>
-          </ion-text>
+          <app-form-error [control]="form.get('email')"></app-form-error>
 
           <ion-item lines="none" *ngIf="!editing">
             <ion-input
@@ -68,21 +49,10 @@
               autocomplete="off"
             ></ion-input>
           </ion-item>
-          <ion-text
-            *ngIf="!editing && form.get('password')?.touched && form.get('password')?.errors"
-            color="danger"
-            class="error-message"
-          >
-            <small *ngIf="form.get('password')?.errors?.['required']">
-              Senha é obrigatória.
-            </small>
-            <small *ngIf="form.get('password')?.errors?.['minlength']">
-              Senha deve ter ao menos 8 caracteres.
-            </small>
-            <small *ngIf="form.get('password')?.errors?.['pattern']">
-              Senha deve conter ao menos um caractere especial.
-            </small>
-          </ion-text>
+          <app-form-error
+            *ngIf="!editing"
+            [control]="form.get('password')"
+          ></app-form-error>
 
           <ion-button
             expand="block"

--- a/frontend/src/app/users/components/add-user/add-user-modal.component.ts
+++ b/frontend/src/app/users/components/add-user/add-user-modal.component.ts
@@ -10,8 +10,8 @@ import {
   IonCardContent,
   IonItem,
   IonInput,
-  IonText,
 } from '@ionic/angular/standalone';
+import { FormErrorComponent } from '../../../shared/form-error/form-error.component';
 import { CommonModule } from '@angular/common';
 import {
   ReactiveFormsModule,
@@ -37,9 +37,9 @@ import { ErrorTranslatorService } from '../../../core/services/error-translator.
     IonCardContent,
     IonItem,
     IonInput,
-    IonText,
     CommonModule,
     ReactiveFormsModule,
+    FormErrorComponent,
   ],
   templateUrl: './add-user-modal.component.html',
   styleUrls: ['./add-user-modal.component.scss'],


### PR DESCRIPTION
## Summary
- create `FormErrorComponent` for reusable error display
- update auth and user forms to use new component

## Testing
- `CI=true npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877e448f9208322afe503be16a2a24d